### PR TITLE
Support RUN_ENVIRONMENT=stress-tests so Ray-related tests can be run repeatedly

### DIFF
--- a/makefile
+++ b/makefile
@@ -40,6 +40,7 @@ docker-run:
 	docker run --rm \
 	    --network none \
 	    --volume $$(pwd)/workspace:/home/host_user/workspace \
+		--env RUN_ENVIRONMENT=$(RUN_ENVIRONMENT) \
 	    --workdir /home/host_user/workspace/ \
 	    pynb-dag-runner \
 	    "$(COMMAND)"
@@ -49,12 +50,18 @@ clean:
 
 test-library:
 	# Run all tests for library and ensure we can build the library wheel file
+	#
+	# Eg.
+	#   make test-library
+	#   make RUN_ENVIRONMENT=stress-tests test-library
 
-	make COMMAND="(\
-	    cd pynb_dag_runner; \
-	    make \
-	        test-pytest \
-	        test-mypy \
-	        test-black \
-	        build \
+	make \
+	    RUN_ENVIRONMENT=$(RUN_ENVIRONMENT) \
+	    COMMAND="(\
+	        cd pynb_dag_runner; \
+	        make \
+	            test-pytest \
+	            test-mypy \
+	            test-black \
+	            build \
 	)" docker-run

--- a/workspace/pynb_dag_runner/conftest.py
+++ b/workspace/pynb_dag_runner/conftest.py
@@ -27,6 +27,6 @@ def repeat_in_stress_tests(f):
     if os.environ.get("RUN_ENVIRONMENT", "") == "stress-tests":
         repeat_count = 50
     else:
-        repeat_count = 15
+        repeat_count = 20
 
     return pytest.mark.parametrize("repeat_count", range(repeat_count))(f)

--- a/workspace/pynb_dag_runner/conftest.py
+++ b/workspace/pynb_dag_runner/conftest.py
@@ -27,6 +27,6 @@ def repeat_in_stress_tests(f):
     if os.environ.get("RUN_ENVIRONMENT", "") == "stress-tests":
         repeat_count = 50
     else:
-        repeat_count = 100
+        repeat_count = 10
 
     return pytest.mark.parametrize("repeat_count", range(repeat_count))(f)

--- a/workspace/pynb_dag_runner/conftest.py
+++ b/workspace/pynb_dag_runner/conftest.py
@@ -27,6 +27,6 @@ def repeat_in_stress_tests(f):
     if os.environ.get("RUN_ENVIRONMENT", "") == "stress-tests":
         repeat_count = 50
     else:
-        repeat_count = 10
+        repeat_count = 5
 
     return pytest.mark.parametrize("repeat_count", range(repeat_count))(f)

--- a/workspace/pynb_dag_runner/conftest.py
+++ b/workspace/pynb_dag_runner/conftest.py
@@ -27,6 +27,6 @@ def repeat_in_stress_tests(f):
     if os.environ.get("RUN_ENVIRONMENT", "") == "stress-tests":
         repeat_count = 50
     else:
-        repeat_count = 1
+        repeat_count = 100
 
     return pytest.mark.parametrize("repeat_count", range(repeat_count))(f)

--- a/workspace/pynb_dag_runner/conftest.py
+++ b/workspace/pynb_dag_runner/conftest.py
@@ -27,6 +27,6 @@ def repeat_in_stress_tests(f):
     if os.environ.get("RUN_ENVIRONMENT", "") == "stress-tests":
         repeat_count = 50
     else:
-        repeat_count = 15
+        repeat_count = 5
 
     return pytest.mark.parametrize("repeat_count", range(repeat_count))(f)

--- a/workspace/pynb_dag_runner/conftest.py
+++ b/workspace/pynb_dag_runner/conftest.py
@@ -27,6 +27,6 @@ def repeat_in_stress_tests(f):
     if os.environ.get("RUN_ENVIRONMENT", "") == "stress-tests":
         repeat_count = 50
     else:
-        repeat_count = 5
+        repeat_count = 10
 
     return pytest.mark.parametrize("repeat_count", range(repeat_count))(f)

--- a/workspace/pynb_dag_runner/conftest.py
+++ b/workspace/pynb_dag_runner/conftest.py
@@ -27,6 +27,6 @@ def repeat_in_stress_tests(f):
     if os.environ.get("RUN_ENVIRONMENT", "") == "stress-tests":
         repeat_count = 50
     else:
-        repeat_count = 10
+        repeat_count = 15
 
     return pytest.mark.parametrize("repeat_count", range(repeat_count))(f)

--- a/workspace/pynb_dag_runner/conftest.py
+++ b/workspace/pynb_dag_runner/conftest.py
@@ -1,4 +1,7 @@
 # location of this file indicates root for pytest
+import os
+
+#
 import pytest, ray
 
 
@@ -9,3 +12,21 @@ def init_ray_before_all_tests():
     #   Hence ray do not need to start when VS Code is discovering tests (which seems
     #   to generate errors).
     ray.init(num_cpus=2)
+
+
+def repeat_in_stress_tests(f):
+    """
+    Some tests currently fail randomly
+
+    With this decorator we can mark tests so that they
+    - run repeatedly when RUN_ENVIRONMENT=stress-tests (to better catch if they fail randomly)
+    - run once in other environments
+
+    For other strategies: https://docs.pytest.org/en/6.2.x/flaky.html
+    """
+    if os.environ.get("RUN_ENVIRONMENT", "") == "stress-tests":
+        repeat_count = 50
+    else:
+        repeat_count = 1
+
+    return pytest.mark.parametrize("repeat_count", range(repeat_count))(f)

--- a/workspace/pynb_dag_runner/conftest.py
+++ b/workspace/pynb_dag_runner/conftest.py
@@ -27,6 +27,6 @@ def repeat_in_stress_tests(f):
     if os.environ.get("RUN_ENVIRONMENT", "") == "stress-tests":
         repeat_count = 50
     else:
-        repeat_count = 20
+        repeat_count = 25
 
     return pytest.mark.parametrize("repeat_count", range(repeat_count))(f)

--- a/workspace/pynb_dag_runner/conftest.py
+++ b/workspace/pynb_dag_runner/conftest.py
@@ -27,6 +27,6 @@ def repeat_in_stress_tests(f):
     if os.environ.get("RUN_ENVIRONMENT", "") == "stress-tests":
         repeat_count = 50
     else:
-        repeat_count = 1
+        repeat_count = 5
 
     return pytest.mark.parametrize("repeat_count", range(repeat_count))(f)

--- a/workspace/pynb_dag_runner/conftest.py
+++ b/workspace/pynb_dag_runner/conftest.py
@@ -27,6 +27,6 @@ def repeat_in_stress_tests(f):
     if os.environ.get("RUN_ENVIRONMENT", "") == "stress-tests":
         repeat_count = 50
     else:
-        repeat_count = 25
+        repeat_count = 1
 
     return pytest.mark.parametrize("repeat_count", range(repeat_count))(f)

--- a/workspace/pynb_dag_runner/conftest.py
+++ b/workspace/pynb_dag_runner/conftest.py
@@ -27,6 +27,6 @@ def repeat_in_stress_tests(f):
     if os.environ.get("RUN_ENVIRONMENT", "") == "stress-tests":
         repeat_count = 50
     else:
-        repeat_count = 5
+        repeat_count = 15
 
     return pytest.mark.parametrize("repeat_count", range(repeat_count))(f)

--- a/workspace/pynb_dag_runner/makefile
+++ b/workspace/pynb_dag_runner/makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 
 test-pytest:
-	echo ">> Checking unit tests ..."
+	echo ">> Checking unit tests (RUN_ENVIRONMENT = ${RUN_ENVIRONMENT})"
 	pytest --durations=10 --continue-on-collection-errors tests
 
 test-mypy:

--- a/workspace/pynb_dag_runner/tests/core/test_dag_runner.py
+++ b/workspace/pynb_dag_runner/tests/core/test_dag_runner.py
@@ -13,8 +13,10 @@ from pynb_dag_runner.core.dag_runner import (
     run_tasks,
 )
 from tests.test_ray_helpers import StateActor
+from conftest import repeat_in_stress_tests
 
 
+@repeat_in_stress_tests
 @pytest.mark.parametrize(
     "task_dependencies",
     [
@@ -26,7 +28,7 @@ from tests.test_ray_helpers import StateActor
         "[task0 >> task1, task1 >> task2, task0 >> task2]",
     ],
 )
-def test_all_tasks_are_run(task_dependencies):
+def test_all_tasks_are_run(repeat_count, task_dependencies):
     def make_task(sleep_secs: float, return_value: int) -> Task[int]:
         @ray.remote(num_cpus=0)
         def f():
@@ -45,8 +47,8 @@ def test_all_tasks_are_run(task_dependencies):
     assert len(result) == 3 and set(result) == set([0, 1, 2])
 
 
-@pytest.mark.parametrize("dummy_loop_parameter", range(1))
-def test_task_run_order(dummy_loop_parameter):
+@repeat_in_stress_tests
+def test_task_run_order(repeat_count):
     state_actor = StateActor.remote()
 
     def make_task(i: int) -> Task[int]:

--- a/workspace/pynb_dag_runner/tests/core/test_task.py
+++ b/workspace/pynb_dag_runner/tests/core/test_task.py
@@ -7,9 +7,11 @@ from pynb_dag_runner.core.dag_runner import (
     TaskDependence,
     TaskDependencies,
 )
+from conftest import repeat_in_stress_tests
 
 
-def test_task_execute_states():
+@repeat_in_stress_tests
+def test_task_execute_states(repeat_count):
     @ray.remote(num_cpus=0)
     def f():
         time.sleep(0.1)
@@ -37,7 +39,8 @@ def test_task_execute_states():
     assert task.result() == ray.get(task.get_ref()) == 1234
 
 
-def test_task_exceptions_should_propagate():
+@repeat_in_stress_tests
+def test_task_exceptions_should_propagate(repeat_count):
     @ray.remote(num_cpus=0)
     def f():
         raise Exception("BOOM123!")


### PR DESCRIPTION
Previously, some tests have failed randomly. 

This will allow us to better check which tests can fail randomly.  