### PR TITLE
Rename `pipeline.` -> `workflow.` parameter prefix

### DIFF
--- a/workspace/README.md
+++ b/workspace/README.md
@@ -11,7 +11,7 @@ generate_static_data --help
 
 #### Expand one OpenTelemetry JSON into a directory structure (eg for debugging)
 ```bash
-# First: copy a pipeline trace JSON to opentelemetry-spans.json
+# First: copy a workflow trace JSON to opentelemetry-spans.json
 pynb_log_parser \
     --input_span_file opentelemetry-spans.json \
     --output_filepath_mermaid_gantt $(pwd)/out/gantt.mmd \

--- a/workspace/pynb_dag_runner/otel_output_parser/cli_generate_static_data.py
+++ b/workspace/pynb_dag_runner/otel_output_parser/cli_generate_static_data.py
@@ -120,7 +120,7 @@ def process(spans: Spans, www_root: Path):
     yield {
         "parent_span_id": None,
         "span_id": pipeline_summary.span_id,
-        "type": "pipeline",
+        "type": "workflow",
         **dict_prefix_keys("timing_", pipeline_summary.timing.as_dict()),
         "is_success": pipeline_summary.is_success(),
         "attributes": pipeline_summary.attributes,

--- a/workspace/pynb_dag_runner/otel_output_parser/cli_generate_static_data.py
+++ b/workspace/pynb_dag_runner/otel_output_parser/cli_generate_static_data.py
@@ -11,8 +11,6 @@ from pynb_dag_runner import version_string
 from pynb_dag_runner.helpers import dict_prefix_keys
 from pynb_dag_runner.opentelemetry_helpers import Spans
 from pynb_dag_runner.opentelemetry_task_span_parser import (
-    # get_pipeline_iterators,
-    # add_html_notebook_artefacts,
     parse_spans,
     ArtifactName,
     ArtifactContent,
@@ -55,7 +53,7 @@ def get_recorded_spans_from_zip(zip_file_content: bytes) -> Spans:
     """
     Input:
        zip_file_content: bytes
-            byte-array with zip file created by pipeline run process with recorded
+            byte-array with zip file created by workflow run process with recorded
             OpenTelemetry spans recorded in a "opentelemetry-spans.json" file.
 
     Output:
@@ -78,21 +76,21 @@ def _write_artifacts(output_path: Path, artifacts):
 
 def process(spans: Spans, www_root: Path):
     pipeline_summary = parse_spans(spans)
-    print("> processing pipeline run", pipeline_summary.span_id)
+    print("> processing workflow run", pipeline_summary.span_id)
 
     pipeline_artifact_relative_root = (
-        Path("artifacts") / "pipeline" / pipeline_summary.span_id
+        Path("artifacts") / "workflow" / pipeline_summary.span_id
     )
 
-    # The below are not real artifacts logged during pipeline execution.
+    # The below are not real artifacts logged during workflow execution.
     # Normal artifacts (and logged values) are only logged on per-task level
-    # (and not on pipeline-level).
+    # (and not on workflow-level).
     #
     # Rather, these are assets generated for reporting/visualisation.
     #
-    # We want to generate these *after the pipeline has run* so these
+    # We want to generate these *after the workflow has run* so these
     # can be generated dynamically and updated independently without having
-    # to rerun the pipeline.
+    # to rerun the workflow.
     #
     reporting_artifacts = [
         ArtifactContent(
@@ -179,10 +177,10 @@ def process(spans: Spans, www_root: Path):
 
 
 def entry_point():
-    print(f"--- generate_static_data cli {version_string()} ---")
-    print("github_repository          :", args().github_repository)
-    print("zip_cache_dir              :", args().zip_cache_dir)
-    print("output_www_root_directory  :", args().output_www_root_directory)
+    print(f"--- generate_static_data cli (v. {version_string()})")
+    print(" - github_repository             :", args().github_repository)
+    print(" - zip_cache_dir                 :", args().zip_cache_dir)
+    print(" - output_www_root_directory     :", args().output_www_root_directory)
 
     entries = []
     for artifact_zip in github_repo_artifact_zips(

--- a/workspace/pynb_dag_runner/otel_output_parser/cli_pynb_log_parser.py
+++ b/workspace/pynb_dag_runner/otel_output_parser/cli_pynb_log_parser.py
@@ -1,15 +1,13 @@
 from pathlib import Path
 from argparse import ArgumentParser
 
-#
+# -
 from pynb_dag_runner import version_string
 from pynb_dag_runner.helpers import read_json, write_json
 from pynb_dag_runner.opentelemetry_helpers import Spans
-from pynb_dag_runner.opentelemetry_task_span_parser import (
-    # get_pipeline_iterators,
-    # add_html_notebook_artefacts,
-    parse_spans,
-)
+from pynb_dag_runner.opentelemetry_task_span_parser import parse_spans
+
+# -
 from .mermaid_graphs import (
     make_mermaid_dag_inputfile,
     make_mermaid_gantt_inputfile,

--- a/workspace/pynb_dag_runner/otel_output_parser/mermaid_graphs.py
+++ b/workspace/pynb_dag_runner/otel_output_parser/mermaid_graphs.py
@@ -24,9 +24,9 @@ def render_seconds(us_range) -> str:
 
 def make_link_to_task_run(task_summary) -> str:
     # -- This is not provided during unit tests
-    if "pipeline.github.repository" in task_summary.attributes:
+    if "workflow.github.repository" in task_summary.attributes:
         repo_owner, repo_name = task_summary.attributes[
-            "pipeline.github.repository"
+            "workflow.github.repository"
         ].split("/")
 
         host = f"https://{repo_owner}.github.io/{repo_name}"

--- a/workspace/pynb_dag_runner/pynb_dag_runner/opentelemetry_task_span_parser.py
+++ b/workspace/pynb_dag_runner/pynb_dag_runner/opentelemetry_task_span_parser.py
@@ -271,10 +271,10 @@ class TaskRunSummary(p.BaseModel):
     #  - format "0x0123456789abcdef", 64 bit.
     span_id: OpenTelemetrySpanId
 
-    # The ID for the parent pipeline OpenTelemetry top span.
+    # The ID for the parent workflow OpenTelemetry top span.
     parent_span_id: OpenTelemetrySpanId
 
-    # eg "train-model", "evaluate-model", "ingest-data"
+    # eg "f", "train-model", "evaluate-model", "ingest-data"
     task_id: NonEmptyString
 
     exceptions: List[Any]
@@ -324,7 +324,7 @@ class TaskRunSummary(p.BaseModel):
         }
 
 
-# --- Data structure to represent: pipeline (of multiple tasks) run summary ---
+# --- Data structure to represent: workflow (of multiple tasks) run summary ---
 
 
 class PipelineSummary(p.BaseModel):
@@ -332,10 +332,10 @@ class PipelineSummary(p.BaseModel):
 
     timing: Timing
 
-    # pipeline-level attributes
+    # workflow-level attributes
     attributes: AttributeMapping
 
-    # summaries of all task runs than executed as part of pipeline
+    # summaries of all task runs than executed as part of workflow
     task_runs: List[TaskRunSummary]
 
     task_dependencies: Set[Any]
@@ -416,7 +416,7 @@ def parse_spans(spans: Spans) -> PipelineSummary:
     #   to determine the time-ranges. Currently we determine the time range
     #   dynamically for now, see below.
     if "workflow.pipeline_run_id" in pipeline_attributes:
-        top_span_id = pipeline_attributes["workflow.pipeline_run_id"]
+        top_span_id = pipeline_attributes["workflow.workflow_run_id"]
     else:
         top_span_id = "NO-TOP-SPAN--TEMP" + str(uuid.uuid4())
 

--- a/workspace/pynb_dag_runner/pynb_dag_runner/opentelemetry_task_span_parser.py
+++ b/workspace/pynb_dag_runner/pynb_dag_runner/opentelemetry_task_span_parser.py
@@ -405,24 +405,18 @@ def parse_spans(spans: Spans) -> PipelineSummary:
 
     Input is all OpenTelemetry spans logged for one pipeline run.
     """
-    pipeline_attributes = spans.get_attributes(
-        allowed_prefixes={
-            # old API (to be removed)
-            "pipeline.",
-            # new Ray workflow-based API
-            "workflow.",
-        }
-    )
+    pipeline_attributes = spans.get_attributes(allowed_prefixes={"workflow."})
 
     # TODO 1:
     # - potentially (top) span_id could also be passed into function as argument
     # - or, we could determine top node dynamically from input spans, provided it is unique
     #
     # TODO 2:
-    # - Move to have a top span for pipeline. use that for ID and time-ranges.
-    #   Currently we determine the time range dynamically for now, see below.
-    if "pipeline.pipeline_run_id" in pipeline_attributes:
-        top_span_id = pipeline_attributes["pipeline.pipeline_run_id"]
+    # - Move to have a top span for every workflow, and use that for span ID
+    #   to determine the time-ranges. Currently we determine the time range
+    #   dynamically for now, see below.
+    if "workflow.pipeline_run_id" in pipeline_attributes:
+        top_span_id = pipeline_attributes["workflow.pipeline_run_id"]
     else:
         top_span_id = "NO-TOP-SPAN--TEMP" + str(uuid.uuid4())
 

--- a/workspace/pynb_dag_runner/pynb_dag_runner/run_pipeline_helpers.py
+++ b/workspace/pynb_dag_runner/pynb_dag_runner/run_pipeline_helpers.py
@@ -27,7 +27,7 @@ def get_github_env_variables() -> Mapping[str, str]:
       from output).
 
     - In the returned dictionary, variables are placed in lower case and prefixed with
-      pipeline.github. For example, the key "pipeline.github.actor" contains the
+      workflow.github. For example, the key "workflow.github.actor" contains the
       Github username who triggered the task run.
     """
     gh_env_vars: List[str] = [
@@ -86,9 +86,14 @@ def get_github_env_variables() -> Mapping[str, str]:
         #
     ]
 
+    def get_var(env_variable: str) -> Optional[str]:
+        if any(s in env_variable.lower() for s in ["token", "secret", "password"]):
+            raise ValueError(f"Tried to inject potential secret {env_variable}")
+        return os.getenv(env_variable)
+
     return _dict_filter_none_values(
         {
-            "pipeline.github." + var.lower().replace("github_", ""): os.getenv(var)
+            "workflow.github." + var.lower().replace("github_", ""): get_var(var)
             for var in gh_env_vars
         }
     )

--- a/workspace/pynb_dag_runner/tests/test_pynb_dag_runner/tasks/python_tasks/test_ok_or_failed_task.py
+++ b/workspace/pynb_dag_runner/tests/test_pynb_dag_runner/tasks/python_tasks/test_ok_or_failed_task.py
@@ -50,7 +50,7 @@ def get_spans(task_should_fail: bool) -> Spans:
                 return 123
 
         task: RemoteTaskP = task_from_python_function(
-            f, attributes={"pipeline.foo": "bar", "task.foo": "my_test_func"}
+            f, attributes={"workflow.foo": "bar", "task.foo": "my_test_func"}
         )
         [outcome] = start_and_await_tasks(
             [task], [task], timeout_s=10, arg="dummy value"
@@ -74,7 +74,7 @@ def test__python_task__ok_or_fail__parsed_spans(task_should_fail: bool):
     pipeline_summary = parse_spans(spans)
 
     assert pipeline_summary.task_dependencies == set()
-    assert pipeline_summary.attributes == {"pipeline.foo": "bar"}
+    assert pipeline_summary.attributes == {"workflow.foo": "bar"}
 
     for task_summary in [one(pipeline_summary.task_runs)]:  # type: ignore
         assert len(task_summary.logged_values) == 0
@@ -82,7 +82,7 @@ def test__python_task__ok_or_fail__parsed_spans(task_should_fail: bool):
 
         assert task_summary.is_success() == (not task_should_fail)
         assert task_summary.attributes == {
-            "pipeline.foo": "bar",
+            "workflow.foo": "bar",
             "task.foo": "my_test_func",
             "task.num_cpus": 1,
             "task.task_type": "Python",

--- a/workspace/pynb_dag_runner/tests/test_pynb_dag_runner/test_run_pipeline_helpers.py
+++ b/workspace/pynb_dag_runner/tests/test_pynb_dag_runner/test_run_pipeline_helpers.py
@@ -19,7 +19,7 @@ def github_env(monkeypatch):
 def test_get_github_env_variables(github_env):
     result = get_github_env_variables()
 
-    assert result["pipeline.github.actor"] == "someone"
-    assert result["pipeline.github.runner_name"] == "my-runner-vm-2"
+    assert result["workflow.github.actor"] == "someone"
+    assert result["workflow.github.runner_name"] == "my-runner-vm-2"
 
     assert "GITHUB_SHA" not in result.keys()


### PR DESCRIPTION
Pipeline still used in commands, variable names and documentation. 