### PR TITLE
Terminology rename for `pipeline` -> `workflow`

### DIFF
--- a/workspace/pynb_dag_runner/otel_output_parser/cli_generate_static_data.py
+++ b/workspace/pynb_dag_runner/otel_output_parser/cli_generate_static_data.py
@@ -73,11 +73,11 @@ def _write_artifacts(output_path: Path, artifacts):
 
 
 def process(spans: Spans, www_root: Path):
-    pipeline_summary = parse_spans(spans)
-    print("> processing workflow run", pipeline_summary.span_id)
+    workflow_summary = parse_spans(spans)
+    print("> processing workflow run", workflow_summary.span_id)
 
     pipeline_artifact_relative_root = (
-        Path("artifacts") / "workflow" / pipeline_summary.span_id
+        Path("artifacts") / "workflow" / workflow_summary.span_id
     )
 
     # The below are not real artifacts logged during workflow execution.
@@ -109,7 +109,7 @@ def process(spans: Spans, www_root: Path):
         ArtifactContent(
             name="run-time-metadata.json",
             type="utf-8",
-            content=json.dumps(pipeline_summary.as_dict(), indent=2),
+            content=json.dumps(workflow_summary.as_dict(), indent=2),
         ),
     ]
 
@@ -117,11 +117,11 @@ def process(spans: Spans, www_root: Path):
     # different from the summary dict created at pipeline runtime.
     yield {
         "parent_span_id": None,
-        "span_id": pipeline_summary.span_id,
+        "span_id": workflow_summary.span_id,
         "type": "workflow",
-        **dict_prefix_keys("timing_", pipeline_summary.timing.as_dict()),
-        "is_success": pipeline_summary.is_success(),
-        "attributes": pipeline_summary.attributes,
+        **dict_prefix_keys("timing_", workflow_summary.timing.as_dict()),
+        "is_success": workflow_summary.is_success(),
+        "attributes": workflow_summary.attributes,
         "artifacts": [
             artifact.metadata_as_dict()
             for artifact in _write_artifacts(
@@ -131,13 +131,13 @@ def process(spans: Spans, www_root: Path):
         ],
     }
 
-    for task_run_summary in pipeline_summary.task_runs:
+    for task_run_summary in workflow_summary.task_runs:
         task_artifact_relative_root = (
             Path("artifacts") / "task" / task_run_summary.span_id
         )
         print(" - task", task_artifact_relative_root)
         yield {
-            "parent_span_id": pipeline_summary.span_id,
+            "parent_span_id": workflow_summary.span_id,
             "span_id": task_run_summary.span_id,
             "type": "task",
             "task_id": task_run_summary.task_id,

--- a/workspace/pynb_dag_runner/otel_output_parser/cli_pynb_log_parser.py
+++ b/workspace/pynb_dag_runner/otel_output_parser/cli_pynb_log_parser.py
@@ -45,13 +45,13 @@ def write_spans_to_output_directory_structure(spans: Spans, out_basepath: Path):
     """
     print(" - Writing tasks in spans to ", out_basepath)
 
-    pipeline_summary = parse_spans(spans)
+    workflow_summary = parse_spans(spans)
 
     write_json(
-        safe_path(out_basepath / "run-time-metadata.json"), pipeline_summary.as_dict()
+        safe_path(out_basepath / "run-time-metadata.json"), workflow_summary.as_dict()
     )
 
-    for task_run_summary in pipeline_summary.task_runs:
+    for task_run_summary in workflow_summary.task_runs:
         # -- write json with task-specific data --
         if task_run_summary.attributes["task.task_type"] == "jupytext":
             task_dir: str = "--".join(

--- a/workspace/pynb_dag_runner/otel_output_parser/mermaid_graphs.py
+++ b/workspace/pynb_dag_runner/otel_output_parser/mermaid_graphs.py
@@ -60,7 +60,7 @@ def make_mermaid_dag_inputfile(spans: Spans, generate_links: bool) -> str:
         "    %%",
     ]
 
-    pipeline_summary = parse_spans(spans)
+    workflow_summary = parse_spans(spans)
 
     def dag_node_id(span_id: str) -> str:
         # span_id:s are of form "0x<hex>" and can not be used as Mermaid node_ids as-is.
@@ -94,7 +94,7 @@ def make_mermaid_dag_inputfile(spans: Spans, generate_links: bool) -> str:
         else:
             return desc
 
-    for task_summary in pipeline_summary.task_runs:
+    for task_summary in workflow_summary.task_runs:
         if task_summary.attributes["task.task_type"] != "jupytext":
             raise Exception(f"Unknown task type for {task_summary}")
 
@@ -106,7 +106,7 @@ def make_mermaid_dag_inputfile(spans: Spans, generate_links: bool) -> str:
         ]
 
     # add links between noded in graph
-    for span_id_from, span_id_to in pipeline_summary.task_dependencies:
+    for span_id_from, span_id_to in workflow_summary.task_dependencies:
         output_lines += [
             f"    {dag_node_id(span_id_from)} --> {dag_node_id(span_id_to)}"
         ]
@@ -130,9 +130,9 @@ def make_mermaid_gantt_inputfile(spans: Spans) -> str:
         "    dateFormat x",
         "    %%",
     ]
-    pipeline_summary = parse_spans(spans)
+    workflow_summary = parse_spans(spans)
 
-    for task_run_summary in pipeline_summary.task_runs:
+    for task_run_summary in workflow_summary.task_runs:
         attributes = task_run_summary.attributes
 
         if attributes["task.task_type"] != "jupytext":

--- a/workspace/pynb_dag_runner/tests/test_pynb_dag_runner/tasks/notebook_tasks/test_always_fail.py
+++ b/workspace/pynb_dag_runner/tests/test_pynb_dag_runner/tasks/notebook_tasks/test_always_fail.py
@@ -35,10 +35,10 @@ def spans() -> Spans:
 
 
 def test__jupytext__always_fail__parse_spans(spans: Spans):
-    pipeline_summary = parse_spans(spans)
+    workflow_summary = parse_spans(spans)
 
     # assert there is one task
-    task_summary = one(pipeline_summary.task_runs)
+    task_summary = one(workflow_summary.task_runs)
 
     # assert that exception is logged
     assert not task_summary.is_success()

--- a/workspace/pynb_dag_runner/tests/test_pynb_dag_runner/tasks/notebook_tasks/test_ok_notebook.py
+++ b/workspace/pynb_dag_runner/tests/test_pynb_dag_runner/tasks/notebook_tasks/test_ok_notebook.py
@@ -35,10 +35,10 @@ def spans_once() -> Spans:
 
 
 def test__jupytext__ok_notebook__parse_spans(spans_once: Spans):
-    pipeline_summary = parse_spans(spans_once)
+    workflow_summary = parse_spans(spans_once)
 
     # assert there is one successful task
-    task_summary = one(pipeline_summary.task_runs)
+    task_summary = one(workflow_summary.task_runs)
     assert task_summary.is_success()
 
     assert task_summary.attributes == {
@@ -72,7 +72,7 @@ def test__jupytext__ok_notebook__parse_spans(spans_once: Spans):
     for name in ["notebook.ipynb", "notebook.html"]:
         validate(one(a for a in task_summary.logged_artifacts if a.name == name))
 
-    assert len(pipeline_summary.task_dependencies) == 0
+    assert len(workflow_summary.task_dependencies) == 0
 
 
 @pytest.fixture(scope="module")
@@ -95,13 +95,13 @@ def spans_run_twice() -> Spans:
 
 
 def test__jupytext__ok_notebook__run_twice(spans_run_twice: Spans):
-    pipeline_summary = parse_spans(spans_run_twice)
+    workflow_summary = parse_spans(spans_run_twice)
 
     # assert there is one successful task
-    assert len(pipeline_summary.task_runs) == 2
+    assert len(workflow_summary.task_runs) == 2
 
-    for task_summary in pipeline_summary.task_runs:
+    for task_summary in workflow_summary.task_runs:
         assert task_summary.is_success()
         assert task_summary.task_id == str(TEST_NOTEBOOK.filepath)
 
-    assert len(pipeline_summary.task_dependencies) == 1
+    assert len(workflow_summary.task_dependencies) == 1

--- a/workspace/pynb_dag_runner/tests/test_pynb_dag_runner/tasks/notebook_tasks/test_otel_logging.py
+++ b/workspace/pynb_dag_runner/tests/test_pynb_dag_runner/tasks/notebook_tasks/test_otel_logging.py
@@ -46,11 +46,11 @@ def spans() -> Spans:
 
 
 def test__jupytext__otel_logging_from_notebook__validate_parsed_spans_new(spans: Spans):
-    pipeline_summary = parse_spans(spans)
+    workflow_summary = parse_spans(spans)
 
-    assert pipeline_summary.is_success()
+    assert workflow_summary.is_success()
 
-    task_summary = one(pipeline_summary.task_runs)
+    task_summary = one(workflow_summary.task_runs)
     assert task_summary.is_success()
 
     # Check: artifact logged from the evaluated notebook

--- a/workspace/pynb_dag_runner/tests/test_pynb_dag_runner/tasks/notebook_tasks/test_stuck_notebook.py
+++ b/workspace/pynb_dag_runner/tests/test_pynb_dag_runner/tasks/notebook_tasks/test_stuck_notebook.py
@@ -35,10 +35,10 @@ def spans() -> Spans:
 
 
 def test__jupytext__stuck_notebook__validate_spans(spans: Spans):
-    pipeline_summary = parse_spans(spans)
-    assert pipeline_summary.is_failure()
+    workflow_summary = parse_spans(spans)
+    assert workflow_summary.is_failure()
 
-    for task_summary in [one(pipeline_summary.task_runs)]:  # type: ignore
+    for task_summary in [one(workflow_summary.task_runs)]:  # type: ignore
         assert task_summary.is_failure()
         assert "timeout" in str(one(task_summary.exceptions)).lower()
 
@@ -59,4 +59,4 @@ def test__jupytext__stuck_notebook__validate_spans(spans: Spans):
 
         assert task_summary.timing.get_duration_s() > TASK_TIMEOUT_S
 
-    assert len(pipeline_summary.task_dependencies) == 0
+    assert len(workflow_summary.task_dependencies) == 0

--- a/workspace/pynb_dag_runner/tests/test_pynb_dag_runner/tasks/python_tasks/test_dag_runner.py
+++ b/workspace/pynb_dag_runner/tests/test_pynb_dag_runner/tasks/python_tasks/test_dag_runner.py
@@ -39,10 +39,10 @@ def test_opentelemetry_baggage_convert_into_strings():
             )
 
     assert len(rec.spans.exception_events()) == 0
-    pipeline_summary = parse_spans(rec.spans)
+    workflow_summary = parse_spans(rec.spans)
 
     # baggage does not modify paramters
-    assert pipeline_summary.attributes == workflow_parameters_out
+    assert workflow_summary.attributes == workflow_parameters_out
 
 
 # --- Check the following DAG ---
@@ -90,16 +90,16 @@ def cl__can_compose_spans() -> Spans:
 
 
 def test__cl__can_compose(cl__can_compose_spans: Spans):
-    pipeline_summary = parse_spans(cl__can_compose_spans)
+    workflow_summary = parse_spans(cl__can_compose_spans)
 
-    assert pipeline_summary.attributes == {"workflow.env": "xyz"}
+    assert workflow_summary.attributes == {"workflow.env": "xyz"}
 
-    assert len(pipeline_summary.task_runs) == 3
+    assert len(workflow_summary.task_runs) == 3
 
     span_id_to_task_id: Dict[str, str] = {}
 
     # check logged workflow and task attributes
-    for task_summary in pipeline_summary.task_runs:  # type: ignore
+    for task_summary in workflow_summary.task_runs:  # type: ignore
         assert task_summary.is_success()
 
         # assert that task has expected attributes logged
@@ -117,8 +117,8 @@ def test__cl__can_compose(cl__can_compose_spans: Spans):
         span_id_to_task_id[task_summary.span_id] = task_id
 
     # check logged task dependencies
-    assert len(pipeline_summary.task_dependencies) == 2
-    for span_id_from, span_id_to in pipeline_summary.task_dependencies:
+    assert len(workflow_summary.task_dependencies) == 2
+    for span_id_from, span_id_to in workflow_summary.task_dependencies:
         task_id_from = span_id_to_task_id[span_id_from]
         task_id_to = span_id_to_task_id[span_id_to]
 

--- a/workspace/pynb_dag_runner/tests/test_pynb_dag_runner/tasks/python_tasks/test_ok_or_failed_task.py
+++ b/workspace/pynb_dag_runner/tests/test_pynb_dag_runner/tasks/python_tasks/test_ok_or_failed_task.py
@@ -52,19 +52,19 @@ def test_spans_a_failed_task_is_not_retried(spans_a_failed_task_is_not_retried: 
     )
 
     # Check parsed spans
-    pipeline_summary = parse_spans(spans_a_failed_task_is_not_retried)
+    workflow_summary = parse_spans(spans_a_failed_task_is_not_retried)
 
-    assert pipeline_summary.attributes == {}
+    assert workflow_summary.attributes == {}
 
-    assert len(pipeline_summary.task_runs) == 1
+    assert len(workflow_summary.task_runs) == 1
 
-    for task_summary in pipeline_summary.task_runs:  # type: ignore
+    for task_summary in workflow_summary.task_runs:  # type: ignore
         assert not task_summary.is_success()
         assert len(task_summary.exceptions) == 1
         assert "BOOM-2000" in str(task_summary.exceptions)
 
     # check logged task dependencies
-    assert len(pipeline_summary.task_dependencies) == 0
+    assert len(workflow_summary.task_dependencies) == 0
 
 
 # --- error handling in case middle task fails in workflow ---
@@ -105,13 +105,13 @@ def test_spans_middle_task_fails(spans_middle_task_fails: Spans):
     assert "this should never be executed" not in str(spans_middle_task_fails.spans)
 
     # Check parsed spans
-    pipeline_summary = parse_spans(spans_middle_task_fails)
+    workflow_summary = parse_spans(spans_middle_task_fails)
 
-    assert pipeline_summary.attributes == {}
+    assert workflow_summary.attributes == {}
 
-    assert len(pipeline_summary.task_runs) == 2
+    assert len(workflow_summary.task_runs) == 2
 
-    for task_summary in pipeline_summary.task_runs:  # type: ignore
+    for task_summary in workflow_summary.task_runs:  # type: ignore
         if task_summary.task_id == "mid-task-f":
             assert task_summary.is_success()
         elif task_summary.task_id == "mid-task-g":
@@ -122,4 +122,4 @@ def test_spans_middle_task_fails(spans_middle_task_fails: Spans):
             raise Exception("Unknown task-id")
 
     # check logged task dependencies
-    assert len(pipeline_summary.task_dependencies) == 1
+    assert len(workflow_summary.task_dependencies) == 1

--- a/workspace/pynb_dag_runner/tests/test_pynb_dag_runner/tasks/python_tasks/test_parallel_tasks.py
+++ b/workspace/pynb_dag_runner/tests/test_pynb_dag_runner/tasks/python_tasks/test_parallel_tasks.py
@@ -36,13 +36,13 @@ def spans_ok() -> Spans:
 
 
 def test__python_task__parallel_tasks__success(spans_ok: Spans):
-    pipeline_summary = parse_spans(spans_ok)
+    workflow_summary = parse_spans(spans_ok)
 
     # check attributes
     ids = []
 
     ranges = []
-    for task_summary in pipeline_summary.task_runs:  # type: ignore
+    for task_summary in workflow_summary.task_runs:  # type: ignore
         assert task_summary.is_success()
         assert len(task_summary.logged_artifacts) == 0
         assert len(task_summary.logged_values) == 0
@@ -86,13 +86,13 @@ def spans_fail() -> Spans:
 
 
 def test__python_task__parallel_tasks__fail(spans_fail: Spans):
-    pipeline_summary = parse_spans(spans_fail)
+    workflow_summary = parse_spans(spans_fail)
 
-    assert pipeline_summary.attributes == {}
+    assert workflow_summary.attributes == {}
 
-    assert len(pipeline_summary.task_runs) == 3
+    assert len(workflow_summary.task_runs) == 3
 
-    for task_summary in pipeline_summary.task_runs:  # type: ignore
+    for task_summary in workflow_summary.task_runs:  # type: ignore
         if task_summary.task_id in ["par-task-f", "par-task-h"]:
             assert task_summary.is_success()
         elif task_summary.task_id == "par-task-g":
@@ -102,7 +102,7 @@ def test__python_task__parallel_tasks__fail(spans_fail: Spans):
         else:
             raise Exception(f"Unknown task-id={task_summary.task_id}")
 
-    assert len(pipeline_summary.task_dependencies) == 0
+    assert len(workflow_summary.task_dependencies) == 0
 
 
 # --- 5 node test dag ---
@@ -166,11 +166,11 @@ def test_5dag_outputs_with_no_errors():
     )
 
     # --- check spans
-    pipeline_summary = parse_spans(spans)
+    workflow_summary = parse_spans(spans)
 
-    assert len(pipeline_summary.task_runs) == 5
-    assert pipeline_summary.is_success()
-    assert len(pipeline_summary.task_dependencies) == 4
+    assert len(workflow_summary.task_runs) == 5
+    assert workflow_summary.is_success()
+    assert len(workflow_summary.task_dependencies) == 4
 
 
 def test_5dag_when_first_node_fails():
@@ -184,13 +184,13 @@ def test_5dag_when_first_node_fails():
     assert expected_result == result
 
     # --- check spans
-    pipeline_summary = parse_spans(spans)
+    workflow_summary = parse_spans(spans)
 
     # Nodes 0 and 1 are executed before computation is short-cirtuited, they sould
     # be in logs
-    assert len(pipeline_summary.task_runs) == 2
-    assert pipeline_summary.is_failure()
-    assert len(pipeline_summary.task_dependencies) == 0
+    assert len(workflow_summary.task_runs) == 2
+    assert workflow_summary.is_failure()
+    assert len(workflow_summary.task_dependencies) == 0
 
 
 def test_5dag_when_first_two_nodes_fail():
@@ -208,11 +208,11 @@ def test_5dag_when_first_two_nodes_fail():
     assert expected_result == result
 
     # --- check spans
-    pipeline_summary = parse_spans(spans)
+    workflow_summary = parse_spans(spans)
 
-    assert len(pipeline_summary.task_runs) == 2
-    assert pipeline_summary.is_failure()
-    assert len(pipeline_summary.task_dependencies) == 0
+    assert len(workflow_summary.task_runs) == 2
+    assert workflow_summary.is_failure()
+    assert len(workflow_summary.task_dependencies) == 0
 
 
 def test_python_task_input_node_may_execute_once_or_separately_for_each_downstream_node():

--- a/workspace/pynb_dag_runner/tests/test_pynb_dag_runner/tasks/python_tasks/test_stuck_task.py
+++ b/workspace/pynb_dag_runner/tests/test_pynb_dag_runner/tasks/python_tasks/test_stuck_task.py
@@ -30,10 +30,10 @@ def spans() -> Spans:
 
 
 def test__python_task__stuck_tasks__parse_spans(spans: Spans):
-    pipeline_summary = parse_spans(spans)
-    assert pipeline_summary.is_failure()
+    workflow_summary = parse_spans(spans)
+    assert workflow_summary.is_failure()
 
-    for task_summary in [one(pipeline_summary.task_runs)]:  # type: ignore
+    for task_summary in [one(workflow_summary.task_runs)]:  # type: ignore
         assert task_summary.is_failure()
         assert "timeout" in str(task_summary.exceptions).lower()
 
@@ -48,4 +48,4 @@ def test__python_task__stuck_tasks__parse_spans(spans: Spans):
 
         assert task_summary.timing.get_duration_s() > TASK_TIMEOUT_S
 
-    assert len(pipeline_summary.task_dependencies) == 0
+    assert len(workflow_summary.task_dependencies) == 0

--- a/workspace/pynb_dag_runner/tests/test_pynb_dag_runner/tasks/python_tasks/test_task_queuing.py
+++ b/workspace/pynb_dag_runner/tests/test_pynb_dag_runner/tasks/python_tasks/test_task_queuing.py
@@ -60,12 +60,12 @@ def test__python_task__parallel_tasks_are_queued_based_on_available_ray_worker_c
     spans: Spans,
 ):
 
-    pipeline_summary = parse_spans(spans)
-    assert len(pipeline_summary.task_runs) == 4
+    workflow_summary = parse_spans(spans)
+    assert len(workflow_summary.task_runs) == 4
 
     task_runtime_ranges = []
 
-    for task_summary in pipeline_summary.task_runs:  # type: ignore
+    for task_summary in workflow_summary.task_runs:  # type: ignore
         assert task_summary.is_success()
         assert len(task_summary.logged_artifacts) == 0
         assert len(task_summary.logged_values) == 0
@@ -79,7 +79,7 @@ def test__python_task__parallel_tasks_are_queued_based_on_available_ray_worker_c
 
     # Check 1: with only 2 CPU:s (reserved for unit tests, see ray.init call)
     # running the above tasks with no constraints should take > 1 secs.
-    assert pipeline_summary.timing.get_duration_s() > 1.0
+    assert workflow_summary.timing.get_duration_s() > 1.0
 
     # Check 2: since only 2 CPU:s are reserved (for unit tests, see above)
     # the intersection of three runtime ranges should always be empty.

--- a/workspace/pynb_dag_runner/tests/test_pynb_dag_runner/tasks/test_task_opentelemetry_logging.py
+++ b/workspace/pynb_dag_runner/tests/test_pynb_dag_runner/tasks/test_task_opentelemetry_logging.py
@@ -159,9 +159,9 @@ def spans_to_test_otel_loggging() -> Spans:
 def test__task_logger__parse_logged_values_from_three_python_tasks(
     spans_to_test_otel_loggging: Spans,
 ):
-    pipeline_summary = parse_spans(spans_to_test_otel_loggging)
+    workflow_summary = parse_spans(spans_to_test_otel_loggging)
 
-    for task_summary in pipeline_summary.task_runs:  # type: ignore
+    for task_summary in workflow_summary.task_runs:  # type: ignore
 
         def check_logged_value(value_name, value_type, value):
             assert task_summary.logged_values[value_name] == LoggedValueContent(


### PR DESCRIPTION
Following switch to new API unify language from pipeline -> workflow. 