### PR TITLE
Support both Jupytext and pure Python tasks

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,5 +1,6 @@
 .PHONY: *
-SHELL := /bin/bash
+SHELL     := /bin/bash
+MAKEFLAGS += --no-print-directory
 
 # --- Helper tasks ---
 
@@ -19,8 +20,9 @@ build-docker-images:
 clean:
 	@(cd workspace/pynb_dag_runner; ${MAKE} clean)
 
-in-ci-docker/build: | env_GITHUB_SHA env_PYTHON_PACKAGE_RELEASE_TARGET env_LAST_COMMIT_UNIX_EPOCH
-	# TODO: allow local run
+in-ci-docker/build: | env_GITHUB_SHA \
+                      env_PYTHON_PACKAGE_RELEASE_TARGET \
+					  env_LAST_COMMIT_UNIX_EPOCH
 	cd docker; \
 	${MAKE} in-ci-docker/run-command \
 	    DOCKER_ARGS=" \
@@ -65,3 +67,14 @@ in-dev-docker/tmux-watch-all-tests:
 	        make tmux-watch-all-tests \
 	            PYTEST_FILTER=\"${PYTEST_FILTER}\" \
 	    )"
+
+in-ci-docker/build-local: | clean
+	@# Build wheel file for local use (in in demo pipeline dev)
+	@${MAKE} in-ci-docker/build \
+	    GITHUB_SHA="$$(git rev-parse HEAD)" \
+	    PYTHON_PACKAGE_RELEASE_TARGET="snapshot-release" \
+	    LAST_COMMIT_UNIX_EPOCH="100000"
+
+	@echo "-------- wheel files ---------"
+	@find . | grep "whl"
+	@echo "------------------------------"

--- a/workspace/pynb_dag_runner/otel_output_parser/cli_pynb_log_parser.py
+++ b/workspace/pynb_dag_runner/otel_output_parser/cli_pynb_log_parser.py
@@ -53,11 +53,11 @@ def write_spans_to_output_directory_structure(spans: Spans, out_basepath: Path):
 
     for task_run_summary in workflow_summary.task_runs:
         # -- write json with task-specific data --
-        if task_run_summary.attributes["task.task_type"] == "jupytext":
+        if task_run_summary.attributes["task.type"] == "jupytext":
             task_dir: str = "--".join(
                 [
-                    "jupytext-notebook-task",
-                    task_run_summary.attributes["task.notebook"]  # type: ignore
+                    "jupytext-task",
+                    task_run_summary.attributes["task.id"]  # type: ignore
                     .replace("/", "-")  # type: ignore
                     .replace(".", "-"),  # type: ignore
                     task_run_summary.span_id,
@@ -114,6 +114,7 @@ def args():
 
 def entry_point():
     print(f"--- pynb_log_parser cli {version_string()} ---")
+    print(f"--- Expand a log into a local directory tree to inspect log output")
 
     spans: Spans = Spans(read_json(args().input_span_file))
     print(f"Number of spans loaded {len(spans)}")

--- a/workspace/pynb_dag_runner/otel_output_parser/cli_pynb_log_parser.py
+++ b/workspace/pynb_dag_runner/otel_output_parser/cli_pynb_log_parser.py
@@ -53,20 +53,21 @@ def write_spans_to_output_directory_structure(spans: Spans, out_basepath: Path):
 
     for task_run_summary in workflow_summary.task_runs:
         # -- write json with task-specific data --
-        if task_run_summary.attributes["task.type"] == "jupytext":
-            task_dir: str = "--".join(
-                [
-                    "jupytext-task",
+        if not task_run_summary.attributes["task.type"] in ["python", "jupytext"]:
+            raise Exception(f"Unknown task type for {task_run_summary.attributes}")
+
+        task_dir: str = "--".join(
+            [
+                f"""{task_run_summary.attributes["task.type"]}-task""",
+                (
                     task_run_summary.attributes["task.id"]  # type: ignore
                     .replace("/", "-")  # type: ignore
-                    .replace(".", "-"),  # type: ignore
-                    task_run_summary.span_id,
-                    outcome(task_run_summary.is_success()),
-                ]
-            )
-
-        else:
-            raise Exception(f"Unknown task type for {task_run_summary.attributes}")
+                    .replace(".", "-")  # type: ignore
+                ),
+                task_run_summary.span_id,
+                outcome(task_run_summary.is_success()),
+            ]
+        )
 
         write_json(
             safe_path(out_basepath / task_dir / "run-time-metadata.json"),

--- a/workspace/pynb_dag_runner/otel_output_parser/mermaid_graphs.py
+++ b/workspace/pynb_dag_runner/otel_output_parser/mermaid_graphs.py
@@ -38,6 +38,14 @@ def make_link_to_task_run(task_summary) -> str:
     return f"{host}/#/experiments/{task_id}/runs/{task_summary.span_id}"
 
 
+def make_header(attributes):
+    # Return a header for task, eg
+    #   "ingest (Python task)""
+    #   "eda (Jupytext task)"
+    #
+    return f"""{attributes["task.id"]} ({attributes["task.type"].capitalize()} task)"""
+
+
 def make_mermaid_dag_inputfile(spans: Spans, generate_links: bool) -> str:
     """
     Generate input file for Mermaid diagram generator for creating dependency diagram
@@ -72,7 +80,7 @@ def make_mermaid_dag_inputfile(spans: Spans, generate_links: bool) -> str:
         # here one could potentially also add total length of task w.
         # outcome status (success/failure)
         return (
-            f"""{attributes["task.id"]} ({attributes["task.type"]} task)""",
+            make_header(attributes),
             list(sorted(out_lines)),
         )
 
@@ -130,7 +138,7 @@ def make_mermaid_gantt_inputfile(spans: Spans) -> str:
         if attributes["task.type"] not in ["jupytext", "python"]:
             raise Exception(f"Unknown task type for {task_run_summary.attributes}")
 
-        output_lines += [f"""    section {attributes["task.id"]}"""]
+        output_lines += [f"""    section {make_header(attributes)}"""]
 
         if task_run_summary.is_success():
             description = "OK"

--- a/workspace/pynb_dag_runner/otel_output_parser/mermaid_graphs.py
+++ b/workspace/pynb_dag_runner/otel_output_parser/mermaid_graphs.py
@@ -62,7 +62,7 @@ def make_mermaid_dag_inputfile(spans: Spans, generate_links: bool) -> str:
         return f"TASK_SPAN_ID_{span_id}"
 
     def dag_node_description(attributes) -> Tuple[str, List[str]]:
-        assert attributes["task.type"] == "jupytext"
+        assert attributes["task.type"] in ["jupytext", "python"]
 
         out_lines = []
         for k, v in attributes.items():
@@ -72,7 +72,7 @@ def make_mermaid_dag_inputfile(spans: Spans, generate_links: bool) -> str:
         # here one could potentially also add total length of task w.
         # outcome status (success/failure)
         return (
-            attributes["task.id"] + " (jupytext task)",
+            f"""{attributes["task.id"]} ({attributes["task.type"]} task)""",
             list(sorted(out_lines)),
         )
 
@@ -90,9 +90,6 @@ def make_mermaid_dag_inputfile(spans: Spans, generate_links: bool) -> str:
             return desc
 
     for task_summary in workflow_summary.task_runs:
-        if task_summary.attributes["task.type"] != "jupytext":
-            raise Exception(f"Unknown task type for {task_summary}")
-
         linkify = lambda x, ys: make_link(x, ys, task_summary)
 
         output_lines += [
@@ -130,7 +127,7 @@ def make_mermaid_gantt_inputfile(spans: Spans) -> str:
     for task_run_summary in workflow_summary.task_runs:
         attributes = task_run_summary.attributes
 
-        if attributes["task.type"] != "jupytext":
+        if attributes["task.type"] not in ["jupytext", "python"]:
             raise Exception(f"Unknown task type for {task_run_summary.attributes}")
 
         output_lines += [f"""    section {attributes["task.id"]}"""]

--- a/workspace/pynb_dag_runner/pynb_dag_runner/opentelemetry_task_span_parser.py
+++ b/workspace/pynb_dag_runner/pynb_dag_runner/opentelemetry_task_span_parser.py
@@ -366,17 +366,10 @@ def _task_run_iterator(
             ),
         }
 
-        # TODO: task_id should be provided when creating a task.
-        # For now determine task_id using the below heuristic
-        task_id: str = "not-available"
-        if "task.task_id" in task_attributes:
-            task_id = task_attributes["task.task_id"]
-        elif "task.notebook" in task_attributes:
-            task_id = (
-                task_attributes["task.notebook"]
-                # -
-                .replace(".py", "").split("/")[-1]
-            )
+        assert "task.id" in task_attributes and isinstance(
+            task_attributes["task.id"], str
+        )
+        task_id: str = task_attributes["task.id"]
 
         yield TaskRunSummary(
             span_id=task_top_span["context"]["span_id"],

--- a/workspace/pynb_dag_runner/pynb_dag_runner/tasks/tasks.py
+++ b/workspace/pynb_dag_runner/pynb_dag_runner/tasks/tasks.py
@@ -13,7 +13,7 @@ from pynb_dag_runner.tasks.task_opentelemetry_logging import _log_named_value
 
 # -
 from pynb_dag_runner.notebooks_helpers import JupytextNotebookContent
-from ..wrappers import task
+from ..wrappers import _task
 
 
 def _get_traceparent() -> str:
@@ -53,14 +53,16 @@ def make_jupytext_task(
     """
     task_parameters: AttributesDict = {
         **parameters,
-        "task.task_type": "jupytext",
-        # TODO: Remove "task.notebook" and make tasks depend on task.task_id instead.
-        # This allows better suport for non-notebook tasks.
-        "task.notebook": str(notebook.filepath),
     }
 
-    @task(
-        task_id=str(notebook.filepath),
+    @_task(
+        # task_id:
+        # Set to notebook filename without an extension as string. Eg
+        # /path/to/ingestion-notebook.py -> ingestion-notebook
+        # The assumption is that we do not have notebooks with the same filenames in
+        # different directories
+        task_id=notebook.filepath.stem,
+        task_type="jupytext",
         task_parameters=task_parameters,
         timeout_s=timeout_s,
         num_cpus=num_cpus,

--- a/workspace/pynb_dag_runner/tests/test_pynb_dag_runner/tasks/notebook_tasks/test_always_fail.py
+++ b/workspace/pynb_dag_runner/tests/test_pynb_dag_runner/tasks/notebook_tasks/test_always_fail.py
@@ -45,15 +45,10 @@ def test__jupytext__always_fail__parse_spans(spans: Spans):
     assert len(task_summary.exceptions) == 1
     assert "This notebook always fails" in str(task_summary.exceptions)
 
-    # asset attributes are logged
-    # (str needed to avoid mypy validation error)
-    assert "notebook_always_fail.py" in str(task_summary.attributes["task.notebook"])
-
     assert task_summary.attributes == {
         **TASK_PARAMETERS,
         "task.num_cpus": 1,
-        "task.task_type": "jupytext",
-        "task.task_id": "notebook_always_fail.py",
-        "task.notebook": "notebook_always_fail.py",
+        "task.type": "jupytext",
+        "task.id": "notebook_always_fail",
         "task.timeout_s": TASK_TIMEOUT_S,
     }

--- a/workspace/pynb_dag_runner/tests/test_pynb_dag_runner/tasks/notebook_tasks/test_ok_notebook.py
+++ b/workspace/pynb_dag_runner/tests/test_pynb_dag_runner/tasks/notebook_tasks/test_ok_notebook.py
@@ -44,9 +44,8 @@ def test__jupytext__ok_notebook__parse_spans(spans_once: Spans):
     assert task_summary.attributes == {
         **TASK_PARAMETERS,
         "task.num_cpus": 1,
-        "task.task_id": str(TEST_NOTEBOOK.filepath),
-        "task.notebook": str(TEST_NOTEBOOK.filepath),  # <-- to be deleted
-        "task.task_type": "jupytext",
+        "task.id": "notebook_ok",
+        "task.type": "jupytext",
         "task.timeout_s": -1,
         # None converted into -1 since OpenTelemetry attributes should be non-null
     }
@@ -79,7 +78,7 @@ def test__jupytext__ok_notebook__parse_spans(spans_once: Spans):
 def spans_run_twice() -> Spans:
     # Return spans for running DAG with two nodes
     #
-    #      "notebook_ok.py"    --->       "notebook_ok.py"
+    #      "notebook_ok"    --->       "notebook_ok"
     #
 
     with SpanRecorder() as rec:
@@ -102,6 +101,6 @@ def test__jupytext__ok_notebook__run_twice(spans_run_twice: Spans):
 
     for task_summary in workflow_summary.task_runs:
         assert task_summary.is_success()
-        assert task_summary.task_id == str(TEST_NOTEBOOK.filepath)
+        assert task_summary.task_id == "notebook_ok"
 
     assert len(workflow_summary.task_dependencies) == 1

--- a/workspace/pynb_dag_runner/tests/test_pynb_dag_runner/tasks/notebook_tasks/test_stuck_notebook.py
+++ b/workspace/pynb_dag_runner/tests/test_pynb_dag_runner/tasks/notebook_tasks/test_stuck_notebook.py
@@ -46,9 +46,8 @@ def test__jupytext__stuck_notebook__validate_spans(spans: Spans):
         assert len(task_summary.logged_values) == 0
 
         assert task_summary.attributes == {
-            "task.task_id": "notebook_stuck.py",
-            "task.task_type": "jupytext",
-            "task.notebook": "notebook_stuck.py",  # <-- to be deleted
+            "task.id": "notebook_stuck",
+            "task.type": "jupytext",
             "task.num_cpus": 1,
             "task.timeout_s": TASK_TIMEOUT_S,
             **TASK_PARAMETERS,

--- a/workspace/pynb_dag_runner/tests/test_pynb_dag_runner/tasks/python_tasks/test_dag_runner.py
+++ b/workspace/pynb_dag_runner/tests/test_pynb_dag_runner/tasks/python_tasks/test_dag_runner.py
@@ -103,11 +103,12 @@ def test__cl__can_compose(cl__can_compose_spans: Spans):
         assert task_summary.is_success()
 
         # assert that task has expected attributes logged
-        task_id: str = task_summary.attributes["task.task_id"]  # type: ignore
+        task_id: str = task_summary.attributes["task.id"]  # type: ignore
         assert task_id in TEST_TASK_ATTRIBUTES
 
         assert task_summary.attributes == {
-            "task.task_id": task_id,
+            "task.id": task_id,
+            "task.type": "python",
             **TEST_TASK_ATTRIBUTES[task_id],
             "workflow.env": "xyz",
             "task.num_cpus": 1,
@@ -142,7 +143,8 @@ def test__cl__function_parameters_contain_task_and_system_and_global_parameters(
     with SpanRecorder() as rec:
         assert run_dag(dag=f(), workflow_parameters=workflow_parameters) == Success(
             {
-                "task.task_id": "test_function",
+                "task.id": "test_function",
+                "task.type": "python",
                 "task.num_cpus": 1,
                 "task.timeout_s": 12.78,
                 **task_parameters,

--- a/workspace/pynb_dag_runner/tests/test_pynb_dag_runner/tasks/python_tasks/test_parallel_tasks.py
+++ b/workspace/pynb_dag_runner/tests/test_pynb_dag_runner/tasks/python_tasks/test_parallel_tasks.py
@@ -47,8 +47,8 @@ def test__python_task__parallel_tasks__success(spans_ok: Spans):
         assert len(task_summary.logged_artifacts) == 0
         assert len(task_summary.logged_values) == 0
 
-        assert task_summary.task_id == task_summary.attributes["task.task_id"]
-        ids.append(task_summary.attributes["task.task_id"])
+        assert task_summary.task_id == task_summary.attributes["task.id"]
+        ids.append(task_summary.attributes["task.id"])
         ranges.append(task_summary.timing.get_task_timestamp_range_us_epoch())
 
     assert set(ids) == {"f-#1", "f-#2"}

--- a/workspace/pynb_dag_runner/tests/test_pynb_dag_runner/tasks/python_tasks/test_stuck_task.py
+++ b/workspace/pynb_dag_runner/tests/test_pynb_dag_runner/tasks/python_tasks/test_stuck_task.py
@@ -41,7 +41,8 @@ def test__python_task__stuck_tasks__parse_spans(spans: Spans):
         assert len(task_summary.logged_values) == 0
 
         assert task_summary.attributes == {
-            "task.task_id": "f-sleep-task",
+            "task.id": "f-sleep-task",
+            "task.type": "python",
             "task.num_cpus": 1,
             "task.timeout_s": TASK_TIMEOUT_S,
         }


### PR DESCRIPTION
- **Breaking change in log format**:
  - Switch to `task.id` and `task.type`
  - Remove `task.notebook`
- By default deduce `task.id` for Jupytext tasks to be filename (without path and `.py` extension) of notebook
- Add make recipe to build wheel locally for easier testing