### PR TITLE
Add support for logging with MLFlow client

### DIFF
--- a/docker/Dockerfile.cicd
+++ b/docker/Dockerfile.cicd
@@ -11,6 +11,9 @@ COPY requirements.txt /home/host_user/
 #   - https://github.com/nteract/papermill/issues/711
 #  jsonschema[format-nongpl]==4.17.3
 #   - avoid dependency errors for python cli:s
+#
+# mypy types install, see
+#   https://github.com/python/mypy/issues/10600
 RUN pip3 install --user -r /home/host_user/requirements.txt
 
 RUN pip3 install --quiet --user \

--- a/docker/makefile
+++ b/docker/makefile
@@ -12,6 +12,9 @@ env_%:
 
 # --- Tasks to build Docker images ---
 
+clean:
+	rm -rf ./.built-docker-images
+
 ${BUILT_DOCKER_LOCK_FILE}-base: Dockerfile.base \
                                 makefile
 	docker build \

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -16,3 +16,5 @@ mlflow-skinny==2.1.1
 fastapi==0.91.0
 pyftpdlib==1.5.7
 uvicorn==0.20.0
+types-requests==2.28.11.14
+types-urllib3==1.26.25.7

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,4 +1,4 @@
-ray[default]==2.2.0
+ray[serve]==2.2.0
 notebook==6.5.2
 jupyter-client==7.4.9
 jupytext==1.14.4
@@ -12,3 +12,5 @@ requests==2.27.1
 python-dateutil==2.8.2
 pydantic==1.10.4
 jsonschema[format-nongpl]==4.17.3
+mlflow-skinny==2.1.1
+fastapi==0.91.0

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,4 +1,4 @@
-ray[serve]==2.2.0
+ray[default]==2.2.0
 notebook==6.5.2
 jupyter-client==7.4.9
 jupytext==1.14.4
@@ -15,3 +15,4 @@ jsonschema[format-nongpl]==4.17.3
 mlflow-skinny==2.1.1
 fastapi==0.91.0
 pyftpdlib==1.5.7
+uvicorn==0.20.0

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -14,3 +14,4 @@ pydantic==1.10.4
 jsonschema[format-nongpl]==4.17.3
 mlflow-skinny==2.1.1
 fastapi==0.91.0
+pyftpdlib==1.5.7

--- a/makefile
+++ b/makefile
@@ -11,6 +11,9 @@ env_%:
 
 # --- docker related tasks ---
 
+docker/clean:
+	@(cd docker; make clean)
+
 build-docker-images:
 	@(cd docker; ${MAKE} build-docker-images)
 

--- a/workspace/composable_logs/composable_logs/helpers.py
+++ b/workspace/composable_logs/composable_logs/helpers.py
@@ -205,7 +205,12 @@ class Try(Generic[A]):
             try:
                 return cls(value=f(*args, **kwargs), error=None)
             except Exception as e:
+
+                # https://github.com/composable-logs/composable-logs/issues/229
                 print(e)
+                import traceback
+
+                print(traceback.format_exc())
                 return cls(value=None, error=e)
 
         return wrapped_f

--- a/workspace/composable_logs/composable_logs/mlflow_server/server.py
+++ b/workspace/composable_logs/composable_logs/mlflow_server/server.py
@@ -1,0 +1,138 @@
+import os
+
+# -
+from fastapi import FastAPI, Request
+
+# ---- start ML Flow server to catch requests ----
+from fastapi import FastAPI, Request, Depends
+from ray import serve
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
+
+
+# -
+from composable_logs.tasks.task_opentelemetry_logging import get_task_context
+from composable_logs.wrappers import _get_traceparent
+
+
+MLFLOW_PORT = 4942
+MLFLOW_HOST = "localhost"
+
+
+def get_api():
+
+    app = FastAPI()
+    _security = HTTPBasic()
+
+    def _get_traceparent(credentials: HTTPBasicCredentials = Depends(_security)):
+        """
+        ML Flow clients use username + password to authenticate.
+
+        The username is the span-id to use as parent-span-id when logging data.
+
+        https://fastapi.tiangolo.com/advanced/security/http-basic-auth/
+        """
+        traceparent: str = credentials.username
+        assert isinstance(traceparent, str)
+        # raise Exception("_get_traceparent" + traceparent)
+        return traceparent
+
+    @serve.deployment(route_prefix="/")
+    @serve.ingress(app)
+    class ServerToCaptureMLFlowData:
+        @app.post("/api/2.0/mlflow/runs/create")
+        async def post_runs_create(
+            self, request: Request, traceparent: str = Depends(_get_traceparent)
+        ):
+            print(
+                "POST >>> /api/2.0/mlflow/runs/create :: reqs json = ",
+                await request.json(),
+            )
+            print("POST >>> /api/2.0/mlflow/runs/create :: creds = ", traceparent)
+
+            # When client starts a new id, the server responds with id for that run.
+            # see https://mlflow.org/docs/latest/rest-api.html#mlflowruninfo
+            new_run_id = "a-new-run-id"
+            return {"run": {"info": {"run_id": new_run_id, "run_uuid": new_run_id}}}
+
+        @app.post("/api/2.0/mlflow/runs/log-parameter")
+        async def post_runs_log_parameter(
+            self, request: Request, traceparent: str = Depends(_get_traceparent)
+        ):
+            request_json = await request.json()
+            print("POST >>> /api/2.0/mlflow/runs/log-parameter", request_json)
+
+            assert request_json.keys() == {"run_uuid", "run_id", "key", "value"}
+
+            ctx = get_task_context(P={"_opentelemetry_traceparent": traceparent})
+            ctx.log_string(request_json["key"], request_json["value"])
+            return {}
+
+        @app.post("/api/2.0/mlflow/runs/update")
+        async def post_runs_update(self, request: Request):
+            print("POST >>> /api/2.0/mlflow/runs/update", await request.json())
+            return {}
+
+        @app.get("/status")
+        def is_alive(self):
+            # this is not part of ML Flow API, but useful to testing API
+            return {"status": "OK"}
+
+        @app.get("/{rest_of_path:path}")
+        def catch_all_get(self, rest_of_path):
+            print("Recieved GET query", rest_of_path)
+            return {}
+
+        @app.post("/{rest_of_path:path}")
+        def catch_all_post(self, rest_of_path):
+            print("Recieved POST query", rest_of_path)
+            return {}
+
+    return ServerToCaptureMLFlowData
+
+
+def is_running() -> bool:
+    try:
+        deployments = serve.list_deployments()
+    except:
+        deployments = {}
+    return "ServerToCaptureMLFlowData" in deployments
+
+
+def ensure_running() -> bool:
+    if is_running():
+        return
+
+    serve.run(get_api().bind(), host=MLFLOW_HOST, port=MLFLOW_PORT)
+
+
+def shutdown() -> bool:
+    # note: this will shutdown all services
+    return serve.shutdown()
+
+
+def configure_mlflow_connection_variables():
+    """
+    To be run inside Ray workflow.
+
+    Set up ML Flow connection variables so client identifes as correct task,
+    and ML Flow data is captured to the correct task.
+    """
+    traceparent: str = _get_traceparent()
+
+    if not isinstance(traceparent, str):
+        raise ValueError(
+            f"Expected OpenTelemetry traceparent to be string. Got {traceparent}"
+        )
+    os.environ["GIT_PYTHON_REFRESH"] = "quiet"
+
+    # Note this works assuming all tasks are run in different Python processes
+    os.environ["MLFLOW_TRACKING_USERNAME"] = traceparent
+    os.environ["MLFLOW_TRACKING_PASSWORD"] = "a-weak-password"
+    os.environ["MLFLOW_TRACKING_URI"] = f"http://{MLFLOW_HOST}:{MLFLOW_PORT}"
+
+    # Avoid ML Flow client hanging due to configuration errors.
+    # We are running ML Flow in same setup/cluster as all other tasks.
+    #
+    # https://mlflow.org/docs/latest/python_api/mlflow.environment_variables.html
+    os.environ["MLFLOW_HTTP_REQUEST_MAX_RETRIES"] = "1"  # default 5
+    os.environ["MLFLOW_HTTP_REQUEST_TIMEOUT"] = "5"  # default 120

--- a/workspace/composable_logs/composable_logs/mlflow_server/server.py
+++ b/workspace/composable_logs/composable_logs/mlflow_server/server.py
@@ -1,24 +1,35 @@
-import os
+import os, uuid
 
 # -
 from fastapi import FastAPI, Request
 
-# ---- start ML Flow server to catch requests ----
+# -
+import ray
+from pathlib import Path
+
 from fastapi import FastAPI, Request, Depends, HTTPException
 
 from ray import serve
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
+from pyftpdlib.authorizers import DummyAuthorizer
+from pyftpdlib.handlers import FTPHandler
+from pyftpdlib.servers import FTPServer
 
 # -
 from composable_logs.tasks.task_opentelemetry_logging import get_task_context
 from composable_logs.wrappers import _get_traceparent
 
 
+# ---- start ML Flow server to catch requests ----
+
+
+COMPOSABLE_LOGS_MLFLOW_FTP_SERVER_PORT = 2449
+
 MLFLOW_PORT = 4942
 MLFLOW_HOST = "localhost"
 
 
-def get_api():
+def get_api(ftp_server_ip: str, ftp_server_port: int):
 
     app = FastAPI()
     _security = HTTPBasic()
@@ -80,7 +91,7 @@ def get_api():
                         "run_uuid": traceparent,
                         # strangely this seems to influence where client write temp
                         # files on local file system before sending them to server (!)
-                        "artifact_uri": f"/tmp/{traceparent}/",
+                        "artifact_uri": f"ftp://{ftp_server_ip}:{ftp_server_port}/{traceparent}/",
                     }
                 }
             }
@@ -134,7 +145,7 @@ def get_api():
             return {}
 
         @app.post("/api/2.0/mlflow/runs/set-tag")
-        async def mlflow_runs_get(
+        async def mlflow_runs_set_tag(
             self, request: Request, traceparent: str = Depends(_get_traceparent)
         ):
             # Server REST API:
@@ -158,26 +169,120 @@ def get_api():
 
         @app.get("/status")
         def is_alive(self):
-            # this is not part of ML Flow API, but useful to testing API
             return {"status": "OK"}
 
         @app.get("/{rest_of_path:path}")
         def catch_all_get(self, rest_of_path):
-            print("Recieved GET query", rest_of_path)
-            # https://mlflow.org/docs/latest/rest-api.html#set-experiment-tag
+            print("Recieved unknown GET request", rest_of_path)
             return HTTPException(
                 status_code=501,
                 detail="query {rest_of_path} not supported in state-less "
                 "mlflow-to-opentelemetry log collector",
             )
-            return {}
 
         @app.post("/{rest_of_path:path}")
         def catch_all_post(self, rest_of_path):
-            print("Recieved POST query", rest_of_path)
-            return {}
+            print("Recieved unknown POST request", rest_of_path)
+            return HTTPException(
+                status_code=501,
+                detail="query {rest_of_path} not supported in state-less "
+                "mlflow-to-opentelemetry log collector",
+            )
 
     return ServerToCaptureMLFlowData
+
+
+# --- FTP Server ---
+
+
+def _split_path(p: Path):
+    """
+    split non-absolute Path into a tuple:
+      "first directory" (as string) and "rest of path" (as Path)
+
+    Eg.,
+      _split_path(Path(abc/<somepath>)) == "abc", Path(<somepath)
+    """
+    assert not p.is_absolute()
+    parts = p.parts
+    assert len(parts) >= 2
+
+    first_part, rest = parts[0], parts[1:]
+
+    return first_part, Path("/".join(rest))
+
+
+@ray.remote(num_cpus=0)
+class ArtifactFTPServer:
+    def __init__(self, tmp_dir: Path):
+        assert isinstance(tmp_dir, Path)
+        assert str(tmp_dir).startswith("/")
+
+        self.tmp_dir = tmp_dir
+
+    def get_server_ip_address(self):
+        # With Ray 2.2 this method should not be needed if we install ray[default].
+        #
+        # https://github.com/ray-project/ray/issues/7431
+        #
+        # ray.experimental.state.api.get_actor
+        # https://docs.ray.io/en/latest/ray-observability/state/ray-state-api-reference.html
+        #
+        return ray.get_runtime_context().worker.node_ip_address
+
+    def start_ftp_server(self):
+
+        # ensure work directory exist
+        self.tmp_dir.mkdir(parents=True, exist_ok=True)
+
+        # v---
+        #
+        # The below is based on example codes provided by pyftpdlib
+        # (MIT licensed, 2/2023)
+        #
+        # https://pyftpdlib.readthedocs.io/en/latest/tutorial.html
+        authorizer = DummyAuthorizer()
+
+        # Give anonymous user permissions: write (w) + mkdir (m) + cd (e)
+        authorizer.add_anonymous(str(self.tmp_dir), perm="wme")
+
+        class CustomFTPHandler(FTPHandler):
+            def __repr__(self):
+                # Temp fix: FTPHandler has a custom __repr__ handler: When logging from
+                # on_file_received (when files are already closed) this seems to fail
+                # with exception "ValueError: I/O operation on closed file".
+                # Unless we something like the below:
+                try:
+                    return super().__repr__()
+                except Exception as e:
+                    return "__repr__ generated Exception: " + str(e)
+
+            def on_file_received(_self, file: str):
+                # do something when a file has been received
+                assert isinstance(file, str)
+
+                # get path of form <traceparent>/<path of artifact in ml flow>
+                relative_path: Path = Path(file).relative_to(self.tmp_dir)
+
+                traceparent, relative_path = _split_path(relative_path)
+                ctx = get_task_context(P={"_opentelemetry_traceparent": traceparent})
+                ctx.log_artefact(str(relative_path), Path(file).read_bytes())
+                os.remove(file)
+
+            def on_incomplete_file_received(self, file: str):
+                os.remove(file)
+
+        handler = CustomFTPHandler
+        handler.authorizer = authorizer
+
+        address = ("", COMPOSABLE_LOGS_MLFLOW_FTP_SERVER_PORT)
+        server = FTPServer(address, handler)
+
+        server.serve_forever()
+        # ^---
+
+
+# --- control functions ---
 
 
 def is_running() -> bool:
@@ -192,7 +297,24 @@ def ensure_running():
     if is_running():
         return
 
-    serve.run(get_api().bind(), host=MLFLOW_HOST, port=MLFLOW_PORT)
+    # start ftp-server
+    ftp_actor = (
+        ArtifactFTPServer
+        # -
+        .remote(tmp_dir=Path(f"/tmp/composable-logs/ftp-{uuid.uuid4()}"))  # type: ignore
+    )
+    ftp_ip: str = ray.get(ftp_actor.get_server_ip_address.remote())
+    ftp_actor.start_ftp_server.remote()  # blocking call and actor will no longer respond
+
+    # start ML Flow API
+    serve.run(
+        get_api(
+            ftp_server_ip=ftp_ip,
+            ftp_server_port=COMPOSABLE_LOGS_MLFLOW_FTP_SERVER_PORT,
+        ).bind(),
+        host=MLFLOW_HOST,
+        port=MLFLOW_PORT,
+    )
 
 
 def shutdown() -> bool:
@@ -217,7 +339,7 @@ def configure_mlflow_connection_variables():
 
     # Note this works assuming all tasks are run in different Python processes
     os.environ["MLFLOW_TRACKING_USERNAME"] = traceparent
-    os.environ["MLFLOW_TRACKING_PASSWORD"] = "a-weak-password"
+    os.environ["MLFLOW_TRACKING_PASSWORD"] = "no-password"
     os.environ["MLFLOW_TRACKING_URI"] = f"http://{MLFLOW_HOST}:{MLFLOW_PORT}"
 
     # Avoid ML Flow client hanging due to configuration errors.

--- a/workspace/composable_logs/composable_logs/mlflow_server/server.py
+++ b/workspace/composable_logs/composable_logs/mlflow_server/server.py
@@ -9,7 +9,6 @@ from pathlib import Path
 
 from fastapi import FastAPI, Request, Depends, HTTPException
 
-from ray import serve
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from pyftpdlib.authorizers import DummyAuthorizer
 from pyftpdlib.handlers import FTPHandler
@@ -22,11 +21,17 @@ from composable_logs.wrappers import _get_traceparent
 
 # ---- start ML Flow server to catch requests ----
 
+MLFLOW_SERVER_ACTOR_NAME = "composable-logs-mlflow-server"
 
+# We set up one FTP server on some node in the Ray cluster
 COMPOSABLE_LOGS_MLFLOW_FTP_SERVER_PORT = 2449
 
+# And one MLFlow server on some (potentially other) node in the Ray cluster
 MLFLOW_PORT = 4942
 MLFLOW_HOST = "localhost"
+
+# Clients request the IP of the server from named actors in the cluster, with
+# ports are defined above.
 
 
 def get_api(ftp_server_ip: str, ftp_server_port: int):
@@ -44,7 +49,6 @@ def get_api(ftp_server_ip: str, ftp_server_port: int):
         """
         traceparent: str = credentials.username
         assert isinstance(traceparent, str)
-        # raise Exception("_get_traceparent" + traceparent)
         return traceparent
 
     def _run_response_json(traceparent: str):
@@ -60,162 +64,158 @@ def get_api(ftp_server_ip: str, ftp_server_port: int):
             }
         }
 
-    @serve.deployment(route_prefix="/")
-    @serve.ingress(app)
-    class ServerToCaptureMLFlowData:
+    # --- runs related endpoints ---
 
-        # --- runs related endpoints ---
+    @app.post("/api/2.0/mlflow/runs/create")
+    async def post_runs_create(
+        request: Request, traceparent: str = Depends(_get_traceparent)
+    ):
+        """
+        When client starts a new id, the server responds with id for that run.
 
-        @app.post("/api/2.0/mlflow/runs/create")
-        async def post_runs_create(
-            self, request: Request, traceparent: str = Depends(_get_traceparent)
-        ):
-            """
-            When client starts a new id, the server responds with id for that run.
+        API Documentation:
+        https://mlflow.org/docs/latest/rest-api.html#mlflowruninfo
+        """
+        print("CL: /api/2.0/mlflow/runs/create : POST REQ ", await request.json())
+        response = _run_response_json(traceparent)
+        print("CL: /api/2.0/mlflow/runs/create : RESP ", response)
+        return response
 
-            API Documentation:
-            https://mlflow.org/docs/latest/rest-api.html#mlflowruninfo
-            """
-            print("CL: /api/2.0/mlflow/runs/create : POST REQ ", await request.json())
-            response = _run_response_json(traceparent)
-            print("CL: /api/2.0/mlflow/runs/create : RESP ", response)
-            return response
+    @app.post("/api/2.0/mlflow/runs/update")
+    async def post_runs_update(request: Request):
+        print("POST >>> /api/2.0/mlflow/runs/update", await request.json())
+        return {}
 
-        @app.post("/api/2.0/mlflow/runs/update")
-        async def post_runs_update(self, request: Request):
-            print("POST >>> /api/2.0/mlflow/runs/update", await request.json())
-            return {}
+    @app.get("/api/2.0/mlflow/runs/get")
+    async def mlflow_runs_get(
+        request: Request, traceparent: str = Depends(_get_traceparent)
+    ):
+        print("CL: /api/2.0/mlflow/runs/get: GET")
+        response = _run_response_json(traceparent)
+        print("CL: /api/2.0/mlflow/runs/get: RESP ", response)
+        return response
 
-        @app.get("/api/2.0/mlflow/runs/get")
-        async def mlflow_runs_get(
-            self, request: Request, traceparent: str = Depends(_get_traceparent)
-        ):
-            print("CL: /api/2.0/mlflow/runs/get: GET")
-            response = _run_response_json(traceparent)
-            print("CL: /api/2.0/mlflow/runs/get: RESP ", response)
-            return response
+    # --- experiment data ---
 
-        # --- experiment data ---
+    @app.post("/api/2.0/mlflow/runs/log-parameter")
+    async def post_runs_log_parameter(
+        request: Request, traceparent: str = Depends(_get_traceparent)
+    ):
+        # https://mlflow.org/docs/latest/python_api/mlflow.html#mlflow.log_param
+        request_json = await request.json()
+        print("CL: /api/2.0/mlflow/runs/log-parameter (post) REQ ", request_json)
 
-        @app.post("/api/2.0/mlflow/runs/log-parameter")
-        async def post_runs_log_parameter(
-            self, request: Request, traceparent: str = Depends(_get_traceparent)
-        ):
-            # https://mlflow.org/docs/latest/python_api/mlflow.html#mlflow.log_param
-            request_json = await request.json()
-            print("CL: /api/2.0/mlflow/runs/log-parameter (post) REQ ", request_json)
+        assert request_json.keys() == {"run_uuid", "run_id", "key", "value"}
+        assert isinstance(request_json["key"], str)
+        assert isinstance(request_json["value"], str)
 
-            assert request_json.keys() == {"run_uuid", "run_id", "key", "value"}
-            assert isinstance(request_json["key"], str)
-            assert isinstance(request_json["value"], str)
+        ctx = get_task_context(P={"_opentelemetry_traceparent": traceparent})
 
-            ctx = get_task_context(P={"_opentelemetry_traceparent": traceparent})
+        # Logged as string; as noted in MLFlow log parameter accepts Any input
+        # but content is stringified before storage.
+        ctx.log_string(request_json["key"], request_json["value"])
+        return {}
 
+    @app.post("/api/2.0/mlflow/runs/log-batch")
+    async def post_runs_log_batch(
+        request: Request, traceparent: str = Depends(_get_traceparent)
+    ):
+        # Batch ingestion of key-value parameters and metrics
+        # https://mlflow.org/docs/latest/rest-api.html#log-batch
+        request_json = await request.json()
+        print("CL: /api/2.0/mlflow/runs/log-batch (post) REQ ", request_json)
+        ctx = get_task_context(P={"_opentelemetry_traceparent": traceparent})
+
+        assert request_json.keys() <= {"run_id", "metrics", "params"}
+
+        assert isinstance(request_json.get("params", []), list)
+        for param in request_json.get("params", []):
+            assert isinstance(param["key"], str)
+            assert isinstance(param["value"], str)
             # Logged as string; as noted in MLFlow log parameter accepts Any input
             # but content is stringified before storage.
-            ctx.log_string(request_json["key"], request_json["value"])
-            return {}
+            ctx.log_string(param["key"], param["value"])
 
-        @app.post("/api/2.0/mlflow/runs/log-batch")
-        async def post_runs_log_batch(
-            self, request: Request, traceparent: str = Depends(_get_traceparent)
-        ):
-            # Batch ingestion of key-value parameters and metrics
-            # https://mlflow.org/docs/latest/rest-api.html#log-batch
-            request_json = await request.json()
-            print("CL: /api/2.0/mlflow/runs/log-batch (post) REQ ", request_json)
-            ctx = get_task_context(P={"_opentelemetry_traceparent": traceparent})
+        assert isinstance(request_json.get("metrics", []), list)
+        # metrics not yet supported.
 
-            assert request_json.keys() <= {"run_id", "metrics", "params"}
+        return {}
 
-            assert isinstance(request_json.get("params", []), list)
-            for param in request_json.get("params", []):
-                assert isinstance(param["key"], str)
-                assert isinstance(param["value"], str)
-                # Logged as string; as noted in MLFlow log parameter accepts Any input
-                # but content is stringified before storage.
-                ctx.log_string(param["key"], param["value"])
+    # --- tags ---
 
-            assert isinstance(request_json.get("metrics", []), list)
-            # metrics not yet supported.
+    @app.post("/api/2.0/mlflow/runs/set-tag")
+    async def mlflow_runs_set_tag(
+        request: Request, traceparent: str = Depends(_get_traceparent)
+    ):
+        # Server REST API:
+        # https://mlflow.org/docs/latest/rest-api.html#set-tag
+        #
+        # Client SDK API:
+        # https://mlflow.org/docs/latest/python_api/mlflow.html#mlflow.set_tag
+        request_json = await request.json()
+        print("CL: /api/2.0/mlflow/runs/set-tag (post) REQ ", request_json)
+        ctx = get_task_context(P={"_opentelemetry_traceparent": traceparent})
 
-            return {}
+        assert request_json.keys() == {"run_uuid", "run_id", "key", "value"}
+        assert isinstance(request_json["key"], str)
+        assert isinstance(request_json["value"], str)
+        ctx.log_string("tags." + request_json["key"], request_json["value"])
+        return {}
 
-        # --- tags ---
+    # --- metrics ---
 
-        @app.post("/api/2.0/mlflow/runs/set-tag")
-        async def mlflow_runs_set_tag(
-            self, request: Request, traceparent: str = Depends(_get_traceparent)
-        ):
-            # Server REST API:
-            # https://mlflow.org/docs/latest/rest-api.html#set-tag
-            #
-            # Client SDK API:
-            # https://mlflow.org/docs/latest/python_api/mlflow.html#mlflow.set_tag
-            request_json = await request.json()
-            print("CL: /api/2.0/mlflow/runs/set-tag (post) REQ ", request_json)
-            ctx = get_task_context(P={"_opentelemetry_traceparent": traceparent})
+    @app.post("/api/2.0/mlflow/runs/log-metric")
+    async def post_runs_log_metric(
+        request: Request, traceparent: str = Depends(_get_traceparent)
+    ):
+        # Server REST API:
+        # https://mlflow.org/docs/latest/rest-api.html#log-metric
+        #
+        # Client SDK API:
+        # https://mlflow.org/docs/latest/python_api/mlflow.html#mlflow.log_metric
+        request_json = await request.json()
+        print("CL: /api/2.0/mlflow/runs/log-metric (post) REQ ", request_json)
 
-            assert request_json.keys() == {"run_uuid", "run_id", "key", "value"}
-            assert isinstance(request_json["key"], str)
-            assert isinstance(request_json["value"], str)
-            ctx.log_string("tags." + request_json["key"], request_json["value"])
-            return {}
+        assert request_json.keys() == {
+            "run_uuid",
+            "run_id",
+            "key",
+            "value",
+            "timestamp",
+            "step",
+        }
+        assert isinstance(request_json["key"], str)
+        assert isinstance(request_json["value"], float)
 
-        # --- metrics ---
+        ctx = get_task_context(P={"_opentelemetry_traceparent": traceparent})
+        ctx.log_float(request_json["key"], request_json["value"])
+        return {}
 
-        @app.post("/api/2.0/mlflow/runs/log-metric")
-        async def post_runs_log_metric(
-            self, request: Request, traceparent: str = Depends(_get_traceparent)
-        ):
-            # Server REST API:
-            # https://mlflow.org/docs/latest/rest-api.html#log-metric
-            #
-            # Client SDK API:
-            # https://mlflow.org/docs/latest/python_api/mlflow.html#mlflow.log_metric
-            request_json = await request.json()
-            print("CL: /api/2.0/mlflow/runs/log-metric (post) REQ ", request_json)
+    # --- the below endpoints are not part of the API but useful for testing ---
 
-            assert request_json.keys() == {
-                "run_uuid",
-                "run_id",
-                "key",
-                "value",
-                "timestamp",
-                "step",
-            }
-            assert isinstance(request_json["key"], str)
-            assert isinstance(request_json["value"], float)
+    @app.get("/status")
+    def status():
+        return {"status": "OK"}
 
-            ctx = get_task_context(P={"_opentelemetry_traceparent": traceparent})
-            ctx.log_float(request_json["key"], request_json["value"])
-            return {}
+    @app.get("/{rest_of_path:path}")
+    def catch_all_get(rest_of_path):
+        print("Recieved unknown GET request", rest_of_path)
+        raise HTTPException(
+            status_code=501,
+            detail=f"GET {rest_of_path} not supported in state-less "
+            "mlflow-to-opentelemetry log collector",
+        )
 
-        # --- the below endpoints are not part of the API but useful for testing ---
+    @app.post("/{rest_of_path:path}")
+    def catch_all_post(rest_of_path):
+        print("Recieved unknown POST request", rest_of_path)
+        raise HTTPException(
+            status_code=501,
+            detail=f"POST {rest_of_path} not supported in state-less "
+            "mlflow-to-opentelemetry log collector",
+        )
 
-        @app.get("/status")
-        def is_alive(self):
-            return {"status": "OK"}
-
-        @app.get("/{rest_of_path:path}")
-        def catch_all_get(self, rest_of_path):
-            print("Recieved unknown GET request", rest_of_path)
-            raise HTTPException(
-                status_code=501,
-                detail=f"GET {rest_of_path} not supported in state-less "
-                "mlflow-to-opentelemetry log collector",
-            )
-
-        @app.post("/{rest_of_path:path}")
-        def catch_all_post(self, rest_of_path):
-            print("Recieved unknown POST request", rest_of_path)
-            raise HTTPException(
-                status_code=501,
-                detail=f"POST {rest_of_path} not supported in state-less "
-                "mlflow-to-opentelemetry log collector",
-            )
-
-    return ServerToCaptureMLFlowData
+    return app
 
 
 # --- FTP Server ---
@@ -308,13 +308,62 @@ class ArtifactFTPServer:
         # ^---
 
 
+@ray.remote(num_cpus=0)
+class MLFlowServer:
+    def __init__(self):
+        pass
+
+    def get_server_ip_address(self):
+        return ray.get_runtime_context().worker.node_ip_address
+
+    def start_server(self):
+
+        # --- start ftp-server ---
+        ftp_actor = (
+            ArtifactFTPServer
+            # -
+            .remote(tmp_dir=Path(f"/tmp/composable-logs/ftp-{uuid.uuid4()}"))  # type: ignore
+        )
+        ftp_ip: str = ray.get(ftp_actor.get_server_ip_address.remote())
+        ftp_actor.start_ftp_server.remote()  # blocking call and actor will no longer respond
+
+        import uvicorn
+
+        app = get_api(
+            ftp_server_ip=ftp_ip,
+            ftp_server_port=COMPOSABLE_LOGS_MLFLOW_FTP_SERVER_PORT,
+        )
+
+        uvicorn.run(app, host="0.0.0.0", port=MLFLOW_PORT)
+
+
 # --- control functions ---
+
+
+def get_actor_ip(actor_id: str):
+
+    from ray.experimental.state.api import get_actor, get_node
+
+    actor = get_actor(actor_id)
+    if actor is None:
+        raise Exception(f"Unable to find actor with id={actor}")
+
+    node = get_node(actor["node_id"])
+    return node["node_ip"]
+
+
+def get_mlflow_server_ip() -> str:
+    # return IP for MLFlow server on this Ray cluster.
+    #
+    # Raise an exception if server is not running
+    actor = ray.get_actor(MLFLOW_SERVER_ACTOR_NAME, namespace="pydar-ray-cluster")
+    return get_actor_ip(actor._actor_id.hex())
 
 
 def is_running() -> bool:
     try:
-        deployments = serve.list_deployments()
-        return "ServerToCaptureMLFlowData" in deployments
+        mlflow_ip = get_mlflow_server_ip()
+        return True
     except:
         return False
 
@@ -323,29 +372,48 @@ def ensure_running():
     if is_running():
         return
 
-    # start ftp-server
-    ftp_actor = (
-        ArtifactFTPServer
+    # --- start ML Flow server ---
+    mlflow_server_actor = (
+        MLFlowServer
         # -
-        .remote(tmp_dir=Path(f"/tmp/composable-logs/ftp-{uuid.uuid4()}"))  # type: ignore
+        .options(name=MLFLOW_SERVER_ACTOR_NAME)
+        # -
+        .remote()  # type: ignore
     )
-    ftp_ip: str = ray.get(ftp_actor.get_server_ip_address.remote())
-    ftp_actor.start_ftp_server.remote()  # blocking call and actor will no longer respond
 
-    # start ML Flow API
-    serve.run(
-        get_api(
-            ftp_server_ip=ftp_ip,
-            ftp_server_port=COMPOSABLE_LOGS_MLFLOW_FTP_SERVER_PORT,
-        ).bind(),
-        host=MLFLOW_HOST,
-        port=MLFLOW_PORT,
+    # The below is non-blocking call to actor, but actor-method is blocking
+    # and actor will no longer respond. But will server API requests.
+    mlflow_server_actor.start_server.remote()
+
+    # Ray reports internal API error without a short delay here
+    import time
+
+    time.sleep(1)
+
+    # Poll the ML Flow /status API until the server has started and starts to respond
+    # See: https://stackoverflow.com/a/35504626
+    import requests
+    from requests.adapters import HTTPAdapter, Retry
+
+    session = requests.Session()
+    session.mount(
+        "http://", HTTPAdapter(max_retries=Retry(total=20, backoff_factor=0.1))
+    )
+    status_url = f"http://{get_mlflow_server_ip()}:{MLFLOW_PORT}/status"
+    print("Checking MLFlow server is running using {status_url}")
+    response = session.get(url=status_url)
+    if response.json() == {"status": "OK"}:
+        return True
+
+    raise Exception(
+        "Could not start MLFlow."
+        "Status endpoint {status_url} returns {response}."
+        "Response JSON = {response.json()}"
     )
 
 
 def shutdown() -> bool:
-    # note: this will shutdown all services
-    return serve.shutdown()
+    ray.kill(ray.get_actor(MLFLOW_SERVER_ACTOR_NAME, namespace="pydar-ray-cluster"))
 
 
 def configure_mlflow_connection_variables():
@@ -366,7 +434,11 @@ def configure_mlflow_connection_variables():
     # Note this works assuming all tasks are run in different Python processes
     os.environ["MLFLOW_TRACKING_USERNAME"] = traceparent
     os.environ["MLFLOW_TRACKING_PASSWORD"] = "no-password"
-    os.environ["MLFLOW_TRACKING_URI"] = f"http://{MLFLOW_HOST}:{MLFLOW_PORT}"
+
+    # get IP to named actor running the MLFlow server on this Ray cluster.
+    # So all clients connect to the same MLFlow server on the Ray cluster.
+    mlflow_server_ip = get_mlflow_server_ip()
+    os.environ["MLFLOW_TRACKING_URI"] = f"http://{mlflow_server_ip}:{MLFLOW_PORT}"
 
     # Avoid ML Flow client hanging due to configuration errors.
     # We are running ML Flow in same setup/cluster as all other tasks.

--- a/workspace/composable_logs/composable_logs/opentelemetry_task_span_parser.py
+++ b/workspace/composable_logs/composable_logs/opentelemetry_task_span_parser.py
@@ -12,7 +12,7 @@ from typing import (
 )
 
 # -
-from composable_logs.helpers import del_key, dict_prefix_keys
+from composable_logs.helpers import del_key, dict_prefix_keys, one
 from composable_logs.opentelemetry_helpers import (
     Spans,
     SpanDict,
@@ -283,6 +283,10 @@ class TaskRunSummary(p.BaseModel):
     # keep track of values/artifacts logged *during run time*
     logged_values: Dict[LoggedValueName, LoggedValueContent]
     logged_artifacts: List[ArtifactContent]
+
+    def get_artifact(self, artifact_name) -> ArtifactContent:
+        # TODO switch artifact into dict as for logged values
+        return one([a for a in self.logged_artifacts if a.name == artifact_name])
 
     # --- input validation
     @p.validator("span_id")

--- a/workspace/composable_logs/tests/test_mlflow_server/test_connection.py
+++ b/workspace/composable_logs/tests/test_mlflow_server/test_connection.py
@@ -36,7 +36,7 @@ def test_mlflow_server_is_running_without_fixture():
 def test_mlflow_server_is_running_with_fixture(mlflow_server):
     assert is_running()
 
-    assert requests.get(f"http://{MLFLOW_HOST}:{MLFLOW_PORT}/status").json() == {
+    assert requests.get(f"http://127.0.0.1:{MLFLOW_PORT}/status").json() == {
         "status": "OK"
     }
 

--- a/workspace/composable_logs/tests/test_mlflow_server/test_connection.py
+++ b/workspace/composable_logs/tests/test_mlflow_server/test_connection.py
@@ -1,0 +1,104 @@
+import random, time, requests
+
+# -
+import pytest
+
+
+# -
+from composable_logs.opentelemetry_helpers import Spans, SpanRecorder
+from composable_logs.opentelemetry_task_span_parser import parse_spans
+from composable_logs.wrappers import task, run_dag
+from composable_logs.mlflow_server.server import (
+    MLFLOW_HOST,
+    MLFLOW_PORT,
+    configure_mlflow_connection_variables,
+    is_running,
+    ensure_running,
+    shutdown,
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def mlflow_server():
+    ensure_running()
+    yield
+    shutdown()
+
+
+def test_mlflow_server_is_running_without_fixture():
+    assert is_running()
+
+
+def test_mlflow_server_is_running_with_fixture(mlflow_server):
+    assert is_running()
+
+    assert requests.get(f"http://{MLFLOW_HOST}:{MLFLOW_PORT}/status").json() == {
+        "status": "OK"
+    }
+
+
+def get_test_spans():
+    # Run two tasks in parallel and check that ML Flow data is not mixed up between
+    # tasks.
+
+    @task(task_id="ml_flow_tester_1")
+    def ml_flow_tester_1():
+        configure_mlflow_connection_variables()
+
+        import mlflow
+
+        for k in range(10):
+            time.sleep(random.random() * 0.12)
+            mlflow.log_param(f"1-logged-key-{k}", "1-value-{k}")
+
+    @task(task_id="ml_flow_tester_2")
+    def ml_flow_tester_2():
+        configure_mlflow_connection_variables()
+
+        import mlflow
+
+        for k in range(10):
+            time.sleep(random.random() * 0.08)
+            mlflow.log_param(f"2-logged-key-{k}", "2-value-{k}")
+
+    with SpanRecorder() as rec:
+        run_dag([ml_flow_tester_1(), ml_flow_tester_2()])
+
+    return rec.spans
+
+
+def test_mlflow_data_from_parallel_tasks_are_split_correctly(mlflow_server):
+    spans: Spans = get_test_spans()
+
+    workflow_summary = parse_spans(spans)
+    assert workflow_summary.is_success()
+
+    for task_summary in workflow_summary.task_runs:  # type: ignore
+        assert len(task_summary.logged_artifacts) == 0
+        assert len(task_summary.logged_values) == 10
+
+        assert task_summary.task_id in ["ml_flow_tester_1", "ml_flow_tester_2"]
+        if task_summary.task_id == "ml_flow_tester_1":
+            assert task_summary.logged_values.keys() == {
+                f"1-logged-key-{k}" for k in range(10)
+            }
+        if task_summary.task_id == "ml_flow_tester_2":
+            assert task_summary.logged_values.keys() == {
+                f"2-logged-key-{k}" for k in range(10)
+            }
+
+
+# def _test_mlflow_logging_different_types():
+#     spans = []
+
+#     for s in spans:
+#         print(100 * "-")
+#         import json
+
+#         print(json.dumps(s, indent=2))
+
+#     # assert task_summary.logged_values["logged-key"] == LoggedValueContent(
+#     #     type="utf-8", content="logged-value"
+#     # )
+
+#     # assert False

--- a/workspace/composable_logs/tests/test_mlflow_server/test_connection.py
+++ b/workspace/composable_logs/tests/test_mlflow_server/test_connection.py
@@ -10,6 +10,7 @@ from composable_logs.opentelemetry_task_span_parser import ArtifactContent
 from composable_logs.opentelemetry_helpers import Spans, SpanRecorder
 from composable_logs.opentelemetry_task_span_parser import parse_spans
 from composable_logs.wrappers import task, run_dag
+from composable_logs.wrappers import _get_traceparent
 from composable_logs.mlflow_server.server import (
     MLFLOW_HOST,
     MLFLOW_PORT,
@@ -124,7 +125,9 @@ def get_test_spans_with_different_inputs():
 
         # --- generate data to mlflow.log_text API ---
         mlflow.log_text("## Hello \nWorld 😊", "README.md")
-        from composable_logs.wrappers import _get_traceparent
+
+        # --- log metrics ---
+        mlflow.log_metric("a-logged-metric", 12.900)
 
         # --- mlflow.active_run() should now is populated ---
         active_run_dict = mlflow.active_run().to_dictionary()
@@ -163,6 +166,11 @@ def test_mlflow_logging_for_different_endpoints_with_mix_test_data(mlflow_server
         )
         assert task_summary.logged_values["bbb"] == LoggedValueContent(
             type="utf-8", content="[1, 23]"
+        )
+
+        # --- metrics currently stored as parameters ---
+        assert task_summary.logged_values["a-logged-metric"] == LoggedValueContent(
+            type="float", content=12.900
         )
 
         # --- verify tag was recorded

--- a/workspace/composable_logs/tests/test_mlflow_server/test_connection.py
+++ b/workspace/composable_logs/tests/test_mlflow_server/test_connection.py
@@ -119,12 +119,8 @@ def get_test_spans_with_different_inputs():
         # --- tag run, loged as a parameter but with a tags. prefix ---
         mlflow.set_tag("version", "2.3.4")
 
-        print("- ---- mlflow.log_tex ----")
-
         # --- generate data to mlflow.log_text API ---
         mlflow.log_text("## Hello \nWorld 😊", "README.md")
-
-        print("- ---- mlflow.log_tex ----")
 
     with SpanRecorder() as rec:
         run_dag(ml_flow_data_generator())
@@ -163,7 +159,9 @@ def test_mlflow_logging_for_different_endpoints_with_mix_test_data(mlflow_server
 
         print(100 * "/", task_summary.logged_artifacts)
         assert task_summary.get_artifact("README.md") == ArtifactContent(
-            name="README.md", type="utf-8", content="## Hello \nWorld 😊"
+            name="README.md",
+            type="bytes",
+            content="## Hello \nWorld 😊".encode("utf-8"),
         )
 
 


### PR DESCRIPTION
Enable users to log experiment data (metrics, parameters, models) into Composable Logs using the familiar ML Flow client. 
